### PR TITLE
Fix high potential count handling and refresh

### DIFF
--- a/client/src/pages/high-potential.tsx
+++ b/client/src/pages/high-potential.tsx
@@ -1,6 +1,6 @@
 // client/src/pages/high-potential.tsx
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -161,6 +161,7 @@ export default function HighPotential() {
   const [results, setResults] = useState<ScanResult[]>([]);
   const { toast } = useToast();
   const { isAuthenticated, signInWithGoogle } = useAuth();
+  const queryClient = useQueryClient();
 
   const scanMutation = useMutation({
     mutationFn: async (): Promise<ScanResult[]> => {
@@ -191,6 +192,7 @@ export default function HighPotential() {
     },
     onSuccess: (data) => {
       setResults(data);
+      queryClient.invalidateQueries({ queryKey: ["high-potential-count"], exact: false });
       toast({
         title: "Scan Complete",
         description: `Found ${data.length} high potential coins`,

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -90,14 +90,8 @@ async function qHighPotentialCount(): Promise<{ count: number | null; ts: number
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({}),
   });
+  if (Array.isArray(post)) return { count: post.length, ts: Date.now() };
   if (post && Array.isArray(post.results)) return { count: post.results.length, ts: Date.now() };
-
-  const arr = await safeJson<any[]>(apiUrl("/api/scanner/high-potential"));
-  if (Array.isArray(arr)) return { count: arr.length, ts: Date.now() };
-
-  const obj = await safeJson<any>(apiUrl("/api/scanner/high-potential"));
-  if (obj && Array.isArray(obj.results)) return { count: obj.results.length, ts: Date.now() };
-
   return { count: null, ts: Date.now() };
 }
 


### PR DESCRIPTION
## Summary
- update the home dashboard high potential query to treat the POST response as an array and remove unused GET fallbacks
- invalidate the high potential count query after scans so the dashboard tile refreshes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dd05d081d483239b6d5c12238b100c