### PR TITLE
Fix AI insights count on dashboard

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -48,7 +48,12 @@ type GainerItem = {
   symbol?: string; pair?: string; ticker?: string;
   change24h?: number | string; priceChangePercent?: number | string;
 };
-type AiOverviewData = { signals?: any[] };
+type AiOverviewData = {
+  overallSentiment?: string;
+  keyInsights?: unknown;
+  tradingRecommendations?: unknown;
+  riskAssessment?: string;
+};
 
 // ---------- Utils ----------
 const nf2 = new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -120,7 +125,18 @@ async function qWatchlistCount(): Promise<number | null> {
 
 async function qAiSignals(): Promise<number | null> {
   const ai = await safeJson<AiOverviewData>(apiUrl("/api/ai/market-overview"));
-  if (ai && Array.isArray(ai.signals)) return ai.signals.length;
+  if (!ai) return null;
+
+  const keyInsights = Array.isArray(ai.keyInsights)
+    ? ai.keyInsights.filter((insight) => typeof insight === "string" && insight.trim() !== "")
+    : null;
+  if (keyInsights && keyInsights.length > 0) return keyInsights.length;
+
+  const recs = Array.isArray(ai.tradingRecommendations)
+    ? ai.tradingRecommendations.filter((rec) => typeof rec === "string" && rec.trim() !== "")
+    : null;
+  if (recs && recs.length > 0) return recs.length;
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- align the AI signals query with the market overview response by counting sanitized key insights and trading recommendations
- update the AI overview typing to reflect the actual payload structure returned by /api/ai/market-overview

## Testing
- npm run check *(fails: TS2688 cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68dd0e32c4748323a43300e8d0acb845