### PR TITLE
Refactor scan page layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -61,7 +61,7 @@ function Router() {
 
       {/* CHARTS + SCAN */}
       <Route path="/charts/:symbol?" component={withLayout(Charts)} />
-      <Route path="/scan/:symbol?" component={withLayout(Scan)} /> {/* ✅ now points to Scan */}
+      <Route path="/scan/:symbol?" component={Scan} /> {/* ✅ now points to Scan */}
 
       {/* 404 */}
       <Route component={NotFound} />

--- a/client/src/components/scanner/scan-summary-stats.tsx
+++ b/client/src/components/scanner/scan-summary-stats.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+interface ScannerSummaryStatsProps {
+  coins: number;
+  advancers: number;
+  decliners: number;
+  avgChange: number;
+  hasResults: boolean;
+}
+
+interface ScannerStatTileProps {
+  label: string;
+  value: string;
+  highlight?: "positive" | "negative";
+}
+
+function ScannerStatTile({ label, value, highlight }: ScannerStatTileProps) {
+  return (
+    <Card className="border-border/60 bg-card/60">
+      <CardContent className="p-4">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </p>
+        <p
+          className={cn(
+            "mt-2 text-lg font-semibold text-foreground",
+            highlight === "positive" && "text-emerald-400",
+            highlight === "negative" && "text-red-400"
+          )}
+        >
+          {value}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ScannerSummaryStats({
+  coins,
+  advancers,
+  decliners,
+  avgChange,
+  hasResults,
+}: ScannerSummaryStatsProps) {
+  const averageDisplay = hasResults
+    ? `${avgChange >= 0 ? "+" : ""}${avgChange.toFixed(2)}%`
+    : "—";
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      <ScannerStatTile label="Coins" value={coins.toLocaleString()} />
+      <ScannerStatTile label="Advancers" value={advancers.toLocaleString()} />
+      <ScannerStatTile label="Decliners" value={decliners.toLocaleString()} />
+      <ScannerStatTile
+        label="Avg 24h %"
+        value={averageDisplay}
+        highlight={
+          hasResults
+            ? avgChange >= 0
+              ? "positive"
+              : "negative"
+            : undefined
+        }
+      />
+    </div>
+  );
+}

--- a/client/src/components/ui/index.ts
+++ b/client/src/components/ui/index.ts
@@ -1,0 +1,6 @@
+export * from "./button";
+export * from "./card";
+export * from "./input";
+export * from "./select";
+export * from "./table";
+export * from "./textarea";


### PR DESCRIPTION
## Summary
- replace bespoke layout helpers on the scan page with AppLayout and shared UI components
- add reusable scanner summary stat tiles and a UI barrel export to simplify imports
- update routing so the scan page supplies its own layout while keeping the existing scanning behaviour intact

## Testing
- `npm run check` *(fails: existing TypeScript issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1b64d1cc83238ef75744936b9fb3