### PR TITLE
Add Vercel scanner and watchlist fallbacks

### DIFF
--- a/api/scanner/high-potential.ts
+++ b/api/scanner/high-potential.ts
@@ -1,0 +1,70 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { technicalIndicators } from "../services/technicalIndicators";
+import {
+  getDefaultUserId,
+  recordScanHistory,
+  type ScanResultLike,
+} from "../utils/demoStore";
+import {
+  ensureMethod,
+  parseJsonBody,
+  sendError,
+} from "../utils/requestHelpers";
+import { buildSampleHighPotential } from "../utils/sampleScannerData";
+
+interface HighPotentialRequest {
+  timeframe?: string;
+  minScore?: number;
+  minVolume?: string | number;
+  excludeStablecoins?: boolean;
+  limit?: number;
+}
+
+const DEFAULT_FILTERS: Required<Pick<HighPotentialRequest, "timeframe" | "minScore" | "excludeStablecoins" | "limit">> = {
+  timeframe: "4h",
+  minScore: 16,
+  excludeStablecoins: true,
+  limit: 8,
+};
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (!ensureMethod(req, res, ["POST"])) return;
+
+  try {
+    const body = parseJsonBody<HighPotentialRequest>(req);
+    const filters = {
+      ...DEFAULT_FILTERS,
+      ...body,
+    };
+
+    let results: ScanResultLike[];
+    try {
+      const scanResults = await technicalIndicators.scanHighPotential(filters);
+      results = Array.isArray(scanResults) ? scanResults : [];
+    } catch (error) {
+      console.error("Falling back to sample high potential payload:", error);
+      results = buildSampleHighPotential();
+    }
+
+    if (filters.limit && Number.isFinite(filters.limit)) {
+      results = results.slice(0, Number(filters.limit));
+    }
+
+    recordScanHistory({
+      userId: getDefaultUserId(),
+      scanType: "high_potential",
+      filters,
+      results,
+    });
+
+    res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate=120");
+    res.status(200).json(results);
+  } catch (error) {
+    if (error instanceof Error && error.message === "invalid_json") {
+      sendError(res, 400, "invalid_json");
+      return;
+    }
+    console.error("Error scanning for high potential symbols:", error);
+    sendError(res, 500, "high_potential_unavailable");
+  }
+}

--- a/api/scanner/history.ts
+++ b/api/scanner/history.ts
@@ -1,0 +1,37 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import {
+  getDefaultUserId,
+  listScanHistory,
+  recordScanHistory,
+} from "../utils/demoStore";
+import { ensureMethod, sendError } from "../utils/requestHelpers";
+import { buildSampleAnalysis } from "../utils/sampleScannerData";
+
+function ensureSeedHistory(userId: string) {
+  const existing = listScanHistory(userId);
+  if (existing.length > 0) return;
+  const sample = buildSampleAnalysis("BTCUSDT");
+  recordScanHistory({
+    userId,
+    scanType: "custom",
+    filters: { symbol: sample.symbol, timeframe: "4h" },
+    results: sample,
+  });
+}
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (!ensureMethod(req, res, ["GET"])) return;
+
+  try {
+    const userId = getDefaultUserId();
+    ensureSeedHistory(userId);
+    const type = typeof req.query?.type === "string" ? req.query.type : undefined;
+    const history = listScanHistory(userId, type);
+
+    res.setHeader("Cache-Control", "s-maxage=15, stale-while-revalidate=30");
+    res.status(200).json(history);
+  } catch (error) {
+    console.error("Error fetching scan history:", error);
+    sendError(res, 500, "history_unavailable");
+  }
+}

--- a/api/scanner/scan.ts
+++ b/api/scanner/scan.ts
@@ -1,0 +1,59 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { technicalIndicators } from "../services/technicalIndicators";
+import {
+  getDefaultUserId,
+  recordScanHistory,
+  type ScanResultLike,
+} from "../utils/demoStore";
+import {
+  ensureMethod,
+  getSymbolFromRequest,
+  parseJsonBody,
+  sendError,
+} from "../utils/requestHelpers";
+import { buildSampleAnalysis } from "../utils/sampleScannerData";
+
+interface ScanRequestBody {
+  symbol?: string;
+  timeframe?: string;
+  filters?: Record<string, unknown>;
+}
+
+const DEFAULT_TIMEFRAME = "4h";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (!ensureMethod(req, res, ["POST"])) return;
+
+  try {
+    const body = parseJsonBody<ScanRequestBody>(req);
+    const symbol = getSymbolFromRequest(body.symbol);
+    const timeframe = typeof body.timeframe === "string" && body.timeframe.trim()
+      ? body.timeframe.trim()
+      : DEFAULT_TIMEFRAME;
+
+    let analysis: ScanResultLike;
+    try {
+      analysis = await technicalIndicators.analyzeSymbol(symbol, timeframe);
+    } catch (error) {
+      console.error(`Falling back to sample scan for ${symbol}:`, error);
+      analysis = buildSampleAnalysis(symbol);
+    }
+
+    recordScanHistory({
+      userId: getDefaultUserId(),
+      scanType: "custom",
+      filters: { symbol, timeframe, ...(body.filters ?? {}) },
+      results: analysis,
+    });
+
+    res.setHeader("Cache-Control", "no-store");
+    res.status(200).json(analysis);
+  } catch (error) {
+    if (error instanceof Error && error.message === "invalid_json") {
+      sendError(res, 400, "invalid_json");
+      return;
+    }
+    console.error("Error performing scan:", error);
+    sendError(res, 500, "scan_failed");
+  }
+}

--- a/api/utils/demoStore.ts
+++ b/api/utils/demoStore.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "crypto";
+
+export type Recommendation =
+  | "strong_buy"
+  | "buy"
+  | "hold"
+  | "sell"
+  | "strong_sell";
+
+export interface IndicatorBreakdown {
+  value?: number;
+  signal?: "bullish" | "bearish" | "neutral";
+  score?: number;
+  tier?: number;
+  description?: string;
+}
+
+export interface ScanResultLike {
+  symbol: string;
+  price: number;
+  indicators: Record<string, IndicatorBreakdown>;
+  totalScore: number;
+  recommendation: Recommendation;
+  meta?: Record<string, unknown> | null;
+}
+
+export interface ScanHistoryEntry {
+  id: string;
+  userId: string;
+  scanType: string;
+  filters?: Record<string, unknown> | null;
+  results?: ScanResultLike | ScanResultLike[] | null;
+  createdAt: string;
+}
+
+export interface WatchlistItemEntry {
+  id: string;
+  userId: string;
+  symbol: string;
+  createdAt: string;
+}
+
+const DEFAULT_USER_ID = "demo-user";
+
+const watchlists = new Map<string, Map<string, WatchlistItemEntry>>();
+const historyMap = new Map<string, ScanHistoryEntry[]>();
+
+function nowISO() {
+  return new Date().toISOString();
+}
+
+function ensureSeedWatchlist(userId: string) {
+  if (watchlists.has(userId)) return;
+  const items = new Map<string, WatchlistItemEntry>();
+  ["BTCUSDT", "ETHUSDT", "SOLUSDT"].forEach((symbol, index) => {
+    items.set(symbol.toUpperCase(), {
+      id: randomUUID(),
+      userId,
+      symbol,
+      createdAt: new Date(Date.now() - index * 86_400_000).toISOString(),
+    });
+  });
+  watchlists.set(userId, items);
+}
+
+export function listWatchlist(userId: string = DEFAULT_USER_ID): WatchlistItemEntry[] {
+  ensureSeedWatchlist(userId);
+  return Array.from(watchlists.get(userId)!.values()).sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
+}
+
+export function upsertWatchlistSymbol(
+  symbol: string,
+  userId: string = DEFAULT_USER_ID,
+): WatchlistItemEntry {
+  const normalized = symbol.trim().toUpperCase();
+  if (!normalized) {
+    throw new Error("invalid_symbol");
+  }
+  ensureSeedWatchlist(userId);
+  const list = watchlists.get(userId)!;
+  let entry = list.get(normalized);
+  if (!entry) {
+    entry = { id: randomUUID(), userId, symbol: normalized, createdAt: nowISO() };
+    list.set(normalized, entry);
+  }
+  return entry;
+}
+
+export function removeWatchlistSymbol(
+  symbol: string,
+  userId: string = DEFAULT_USER_ID,
+): boolean {
+  const normalized = symbol.trim().toUpperCase();
+  if (!normalized) return false;
+  ensureSeedWatchlist(userId);
+  const list = watchlists.get(userId)!;
+  const existed = list.delete(normalized);
+  return existed;
+}
+
+export function recordScanHistory(
+  entry: Omit<ScanHistoryEntry, "id" | "createdAt"> & {
+    id?: string;
+    createdAt?: string;
+  },
+): ScanHistoryEntry {
+  const userId = entry.userId || DEFAULT_USER_ID;
+  const payload: ScanHistoryEntry = {
+    id: entry.id ?? randomUUID(),
+    userId,
+    scanType: entry.scanType,
+    filters: entry.filters ?? null,
+    results: entry.results ?? null,
+    createdAt: entry.createdAt ?? nowISO(),
+  };
+  const list = historyMap.get(userId) ?? [];
+  const next = [payload, ...list].slice(0, 25);
+  historyMap.set(userId, next);
+  return payload;
+}
+
+export function listScanHistory(
+  userId: string = DEFAULT_USER_ID,
+  scanType?: string,
+): ScanHistoryEntry[] {
+  const list = historyMap.get(userId) ?? [];
+  if (!scanType) return list;
+  return list.filter((entry) => entry.scanType === scanType);
+}
+
+export function getDefaultUserId() {
+  return DEFAULT_USER_ID;
+}

--- a/api/utils/requestHelpers.ts
+++ b/api/utils/requestHelpers.ts
@@ -1,0 +1,44 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export function ensureMethod(
+  req: VercelRequest,
+  res: VercelResponse,
+  allowed: string[],
+): boolean {
+  if (!allowed.includes(req.method ?? "")) {
+    res.setHeader("Allow", allowed.join(", "));
+    res.status(405).json({ ok: false, error: "method_not_allowed" });
+    return false;
+  }
+  return true;
+}
+
+export function parseJsonBody<T = Record<string, unknown>>(req: VercelRequest): T {
+  const body = req.body;
+  if (!body) {
+    return {} as T;
+  }
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body) as T;
+    } catch (error) {
+      throw new Error("invalid_json");
+    }
+  }
+  return body as T;
+}
+
+export function getSymbolFromRequest(raw: unknown, fallback = "BTCUSDT"): string {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed) {
+      const upper = trimmed.toUpperCase();
+      return upper.endsWith("USDT") ? upper : `${upper}USDT`;
+    }
+  }
+  return fallback;
+}
+
+export function sendError(res: VercelResponse, status: number, error: string, detail?: unknown) {
+  res.status(status).json({ ok: false, error, detail });
+}

--- a/api/utils/sampleScannerData.ts
+++ b/api/utils/sampleScannerData.ts
@@ -1,0 +1,66 @@
+import type { ScanResultLike } from "./demoStore";
+
+const BASE_INDICATORS: ScanResultLike["indicators"] = {
+  rsi: {
+    value: 56.2,
+    signal: "bullish",
+    score: 3,
+    tier: 2,
+    description: "RSI trending higher but below overbought territory.",
+  },
+  macd: {
+    value: 1.8,
+    signal: "bullish",
+    score: 4,
+    tier: 3,
+    description: "MACD crossed above signal line with widening histogram.",
+  },
+  ema_crossover: {
+    value: 0,
+    signal: "bullish",
+    score: 5,
+    tier: 3,
+    description: "Short-term EMA has crossed above long-term EMA, indicating strong momentum.",
+  },
+  bollinger: {
+    value: 0,
+    signal: "neutral",
+    score: 1,
+    tier: 1,
+    description: "Price consolidating mid-band awaiting breakout confirmation.",
+  },
+  adx: {
+    value: 28,
+    signal: "bullish",
+    score: 3,
+    tier: 2,
+    description: "Trending environment with ADX above 25.",
+  },
+};
+
+export function buildSampleAnalysis(symbol: string): ScanResultLike {
+  const priceSeed = symbol.charCodeAt(0) * 10 + symbol.charCodeAt(symbol.length - 1);
+  const price = 25_000 + (priceSeed % 7_500);
+  const totalScore = 18 + (priceSeed % 6);
+  return {
+    symbol,
+    price,
+    indicators: BASE_INDICATORS,
+    totalScore,
+    recommendation: totalScore > 20 ? "strong_buy" : "buy",
+    meta: { sample: true },
+  };
+}
+
+export function buildSampleHighPotential(): ScanResultLike[] {
+  return ["BTCUSDT", "ETHUSDT", "SOLUSDT", "AVAXUSDT", "LINKUSDT", "MATICUSDT"].map(
+    (symbol, index) => {
+      const analysis = buildSampleAnalysis(symbol);
+      return {
+        ...analysis,
+        totalScore: analysis.totalScore + index,
+        recommendation: index < 2 ? "strong_buy" : "buy",
+      };
+    },
+  );
+}

--- a/api/watchlist.ts
+++ b/api/watchlist.ts
@@ -1,9 +1,0 @@
-// api/watchlist.ts
-export default function handler(_req: any, res: any) {
-  res.setHeader("Cache-Control", "s-maxage=30, stale-while-revalidate=60");
-  res.status(200).json({
-    ok: true,
-    items: [],
-    time: new Date().toISOString(),
-  });
-}

--- a/api/watchlist/[symbol].ts
+++ b/api/watchlist/[symbol].ts
@@ -1,0 +1,22 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getDefaultUserId, removeWatchlistSymbol } from "../utils/demoStore";
+import { ensureMethod, sendError } from "../utils/requestHelpers";
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (!ensureMethod(req, res, ["DELETE"])) return;
+
+  try {
+    const symbolParam = req.query?.symbol;
+    const symbol = Array.isArray(symbolParam) ? symbolParam[0] : symbolParam;
+    if (!symbol || typeof symbol !== "string" || !symbol.trim()) {
+      sendError(res, 400, "invalid_symbol");
+      return;
+    }
+
+    const removed = removeWatchlistSymbol(symbol, getDefaultUserId());
+    res.status(200).json({ success: removed });
+  } catch (error) {
+    console.error("Error removing from watchlist:", error);
+    sendError(res, 500, "watchlist_remove_failed");
+  }
+}

--- a/api/watchlist/index.ts
+++ b/api/watchlist/index.ts
@@ -1,0 +1,45 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import {
+  getDefaultUserId,
+  listWatchlist,
+  upsertWatchlistSymbol,
+} from "../utils/demoStore";
+import { ensureMethod, parseJsonBody, sendError } from "../utils/requestHelpers";
+
+interface WatchlistBody {
+  symbol?: string;
+}
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === "GET") {
+    try {
+      const items = listWatchlist(getDefaultUserId());
+      res.setHeader("Cache-Control", "s-maxage=15, stale-while-revalidate=30");
+      res.status(200).json(items);
+    } catch (error) {
+      console.error("Error fetching watchlist:", error);
+      sendError(res, 500, "watchlist_unavailable");
+    }
+    return;
+  }
+
+  if (!ensureMethod(req, res, ["POST"])) return;
+
+  try {
+    const body = parseJsonBody<WatchlistBody>(req);
+    const symbol = body.symbol;
+    if (!symbol || typeof symbol !== "string" || !symbol.trim()) {
+      sendError(res, 400, "invalid_symbol");
+      return;
+    }
+    const entry = upsertWatchlistSymbol(symbol, getDefaultUserId());
+    res.status(200).json(entry);
+  } catch (error) {
+    if (error instanceof Error && error.message === "invalid_json") {
+      sendError(res, 400, "invalid_json");
+      return;
+    }
+    console.error("Error updating watchlist:", error);
+    sendError(res, 500, "watchlist_update_failed");
+  }
+}


### PR DESCRIPTION
## Summary
- add Vercel API handlers for scanner scan, history, and high-potential routes with live analysis attempts and resilient fallbacks
- replace the watchlist stub with GET/POST/DELETE handlers backed by a shared demo data store so the UI can toggle items
- introduce shared request helpers plus demo storage and sample analysis builders to keep the serverless endpoints consistent

## Testing
- npm run check *(fails: missing `node` and `vite/client` type definition entries referenced by tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1a5e0fcc8323b7574b0acdfeea7b