### PR TITLE
Fix API rewrite configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,6 @@
     { "source": "/api", "destination": "/api/index" },
     { "source": "/api/ping", "destination": "/api/ping" },
     { "source": "/api/all", "destination": "/api/all" },
-    { "source": "/api/all/(.*)", "destination": "/api/all?path=$1" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- remove the broad /api/all catch-all rewrite from vercel.json to let other API routes resolve normally

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd4496ae0c8323abaeb1bd02525913