### PR TITLE
Add explicit rewrite for legacy api/all paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,7 @@
     { "source": "/api", "destination": "/api/index" },
     { "source": "/api/ping", "destination": "/api/ping" },
     { "source": "/api/all", "destination": "/api/all" },
+    { "source": "/api/all/(.*)", "destination": "/api/all?path=$1" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- add a targeted rewrite so /api/all/* continues to proxy through api/all without shadowing nested API routes

## Testing
- curl -s -o /tmp/scan.json -w "%{http_code}\n" -X POST http://localhost:3333/api/scanner/scan -H 'Content-Type: application/json' -d '{"symbol":"BTCUSDT","timeframe":"1h"}'
- curl -s -o /tmp/history.json -w "%{http_code}\n" http://localhost:3333/api/scanner/history
- curl -s -o /tmp/high.json -w "%{http_code}\n" -X POST http://localhost:3333/api/scanner/high-potential -H 'Content-Type: application/json' -d '{}'
- curl -s -o /tmp/watchlist.json -w "%{http_code}\n" http://localhost:3333/api/watchlist
- curl -s -o /tmp/watchlist_del.json -w "%{http_code}\n" -X DELETE http://localhost:3333/api/watchlist/BTCUSDT
- curl -s -o /tmp/gainers.json -w "%{http_code}\n" http://localhost:3333/api/market/gainers


------
https://chatgpt.com/codex/tasks/task_e_68dd48f480c8832398b49eaf889fbc26