### PR TITLE
Inline charts page layout wrapper

### DIFF
--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -569,11 +569,8 @@ export default function Charts() {
     </div>
   );
 
-  const pageWrapperClassName =
-    "mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 md:px-6";
-
   return (
-    <div className={pageWrapperClassName}>
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 md:px-6">
       <header className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
           <div>


### PR DESCRIPTION
## Summary
- inline the charts page wrapper div so it is returned directly without an extra layout component
- keep the existing spacing classes on the charts page root container for consistent spacing

## Testing
- ✅ npx --yes serve -s public -l 4173

------
https://chatgpt.com/codex/tasks/task_e_68dd4b6af724832395b89e9a2680e382