### PR TITLE
Remove rewrite that intercepted API routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,6 @@
     { "source": "/api", "destination": "/api/index" },
     { "source": "/api/ping", "destination": "/api/ping" },
     { "source": "/api/all", "destination": "/api/all" },
-    { "source": "/api/all/(.*)", "destination": "/api/all?path=$1" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- drop the catch-all `/api/all/(.*)` rewrite that redirected nested API paths to the legacy handler so individual API endpoints resolve to their own files

## Testing
- not run (installation failed locally due to ENOTEMPTY while running npm install)


------
https://chatgpt.com/codex/tasks/task_e_68dd586c8b348323aa5fb97ce07549b8