### PR TITLE
Remove scan route from navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,7 +18,6 @@ import HighPotential from "@/pages/high-potential";
 import Gainers from "@/pages/gainers";
 import AIInsights from "@/pages/ai-insights";
 import Charts from "@/pages/charts";
-import Scan from "@/pages/scan"; // ✅ NEW
 
 // (keep for later) Protected HOC
 function Protected<T extends React.ComponentType<any>>(Component: T) {
@@ -59,9 +58,8 @@ function Router() {
       <Route path="/gainers" component={withLayout(Gainers)} />
       <Route path="/ai-insights" component={withLayout(AIInsights)} />
 
-      {/* CHARTS + SCAN */}
+      {/* CHARTS */}
       <Route path="/charts/:symbol?" component={withLayout(Charts)} />
-      <Route path="/scan/:symbol?" component={Scan} /> {/* ✅ now points to Scan */}
 
       {/* 404 */}
       <Route component={NotFound} />


### PR DESCRIPTION
## Summary
- remove the Scan page import from the app router
- drop the /scan route so the page is no longer reachable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd821e6eb48323819965c733686a7e