### PR TITLE
Update sidebar analyse navigation

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -60,9 +60,9 @@ export function Sidebar() {
         {/* Dashboard */}
         <SidebarItem to="/dashboard">Dashboard</SidebarItem>
 
-        {/* Charts / Scan (single menu item, active for /charts or /scan) */}
-        <SidebarItem to="/charts" activeWhen={/^\/(charts|scan)(\/|$)/}>
-          Charts / Scan
+        {/* Analyse (single menu item, active for /charts or /analyse) */}
+        <SidebarItem to="/charts" activeWhen={/^\/(charts|analyse)(\/|$)/}>
+          Analyse
         </SidebarItem>
 
         {/* Gainers */}


### PR DESCRIPTION
## Summary
- update the sidebar menu label to "Analyse"
- limit the menu item active state to the charts and analyse routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd82e6109c83238c77d58efa850edc