### PR TITLE
Sync analyse and charts timeframe query parameters

### DIFF
--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -133,10 +133,30 @@ export default function Analyse() {
   const { isAuthenticated, signInWithGoogle } = useAuth();
 
   const [matchWithParam, params] = useRoute("/analyse/:symbol?");
-  const [, setLocation] = useLocation();
-  const urlParams = new URLSearchParams(
-    typeof window !== "undefined" ? window.location.search : "",
+  const [location, setLocation] = useLocation();
+
+  const locationInfo = useMemo(() => {
+    const rawLocation = location ?? "";
+    const withoutHash = rawLocation.startsWith("#")
+      ? rawLocation.slice(1)
+      : rawLocation;
+    const [pathPart = "", searchPart = ""] = withoutHash.split("?");
+    const normalizedPath = pathPart
+      ? pathPart.startsWith("/")
+        ? pathPart
+        : `/${pathPart}`
+      : "/";
+    return {
+      path: normalizedPath,
+      search: searchPart,
+    };
+  }, [location]);
+
+  const urlParams = useMemo(
+    () => new URLSearchParams(locationInfo.search),
+    [locationInfo.search],
   );
+
   const querySymbol = urlParams.get("symbol");
   const shouldAutoScan = urlParams.get("scan") === "true";
   const queryTimeframe = urlParams.get("tf");
@@ -146,6 +166,7 @@ export default function Analyse() {
 
   const [selectedSymbol, setSelectedSymbol] = useState<string>(initialSymbol);
   const [selectedTimeframe, setSelectedTimeframe] = useState<string>(initialTimeframe);
+  const syncingFromQueryRef = useRef(false);
   const [searchInput, setSearchInput] = useState<string>(() => {
     const base = initialSymbol.endsWith("USDT") ? initialSymbol.slice(0, -4) : initialSymbol;
     return base || "BTC";
@@ -155,24 +176,39 @@ export default function Analyse() {
   useEffect(() => {
     const nextSymbol = toUsdtSymbol(params?.symbol || querySymbol || DEFAULT_SYMBOL);
     if (nextSymbol !== selectedSymbol) {
+      syncingFromQueryRef.current = true;
       setSelectedSymbol(nextSymbol);
     }
     const nextTimeframe = toFrontendTimeframe(queryTimeframe || undefined);
     if (nextTimeframe !== selectedTimeframe) {
+      syncingFromQueryRef.current = true;
       setSelectedTimeframe(nextTimeframe);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params?.symbol, querySymbol, queryTimeframe]);
 
   useEffect(() => {
-    if (matchWithParam) {
-      const target = `/analyse/${selectedSymbol}?tf=${selectedTimeframe}`;
-      if (!window.location.hash.endsWith(target)) {
-        setLocation(target);
-      }
+    if (!matchWithParam) return;
+
+    if (syncingFromQueryRef.current) {
+      syncingFromQueryRef.current = false;
+      return;
+    }
+
+    const nextParams = new URLSearchParams(locationInfo.search);
+    nextParams.set("tf", selectedTimeframe);
+    const queryString = nextParams.toString();
+    const targetPath = `/analyse/${selectedSymbol}`;
+    const target = queryString ? `${targetPath}?${queryString}` : targetPath;
+    const current = `${locationInfo.path}${
+      locationInfo.search ? `?${locationInfo.search}` : ""
+    }`;
+
+    if (current !== target) {
+      setLocation(target);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSymbol, selectedTimeframe]);
+  }, [selectedSymbol, selectedTimeframe, locationInfo.path, locationInfo.search, matchWithParam]);
 
   const [priceData, setPriceData] = useState<PriceData | null>(null);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- derive analyse and charts timeframe defaults from the hash-based query string so backend values map to the TIMEFRAMES list
- keep existing query parameters when updating the analyse/charts routes and respond to incoming timeframe links without overwriting them
- guard router pushes triggered by query-derived state to avoid clobbering externally provided symbol/timeframe combinations

## Testing
- npm run build *(fails: vite not found in PATH on this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb4e0b66c8323a13fdf3175c05596