### PR TITLE
chore(vercel): stop ignoring /api functions

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,7 +1,3 @@
-# Ignore everything in /api except the single route we need now
-api/**
-!api/portfolio.js
-
 # Usual ignores
 node_modules
 .vscode


### PR DESCRIPTION
## Summary
- remove the pattern that excluded api routes from the Vercel ignore list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de639e1aac8323b948dda96b5081ce