### PR TITLE
Adjust analyse scan mutation to use API helper

### DIFF
--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -251,10 +251,14 @@ export default function Analyse() {
     mutationFn: async () => {
       const timeframeConfig = TIMEFRAMES.find((tf) => tf.value === selectedTimeframe);
       const backendTimeframe = timeframeConfig?.backend || selectedTimeframe;
-      const res = await apiRequest("POST", "/api/scanner/scan", {
-        symbol: selectedSymbol,
-        timeframe: backendTimeframe,
-      });
+      const res = await apiRequest(
+        "POST",
+        `${API_BASE || ""}/api/scanner/scan`,
+        {
+          symbol: selectedSymbol,
+          timeframe: backendTimeframe,
+        },
+      );
       return (await res.json()) as ScanResult;
     },
     onSuccess: (data) => {


### PR DESCRIPTION
## Summary
- update the analyse page's scan mutation to call apiRequest with the configured API base URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfdaeb58fc83239d5e7dc74d6ef510