### PR TITLE
Add options bag to Binance ticker stream helper

### DIFF
--- a/client/src/components/home/LiveSummary.tsx
+++ b/client/src/components/home/LiveSummary.tsx
@@ -40,8 +40,10 @@ export default function LiveSummary({ symbols = ["BTCUSDT", "ETHUSDT"] }: Props)
   const [tickers, setTickers] = useState<Record<string, Ticker>>({});
 
   useEffect(() => {
-    const unsubscribe = openSpotTickerStream(symbols, (t) => {
-      setTickers((prev) => ({ ...prev, [t.symbol]: t }));
+    const unsubscribe = openSpotTickerStream(symbols, {
+      onMessage: (t) => {
+        setTickers((prev) => ({ ...prev, [t.symbol]: t }));
+      },
     });
     return unsubscribe;
   }, [symbols.join("|")]); // stable enough for this simple case

--- a/client/src/lib/binanceWs.ts
+++ b/client/src/lib/binanceWs.ts
@@ -1,33 +1,127 @@
 // client/src/lib/binanceWs.ts
 export type Ticker = {
-  symbol: string; lastPrice: string; priceChange: string; priceChangePercent: string;
-  highPrice: string; lowPrice: string; volume: string; quoteVolume: string;
+  symbol: string;
+  lastPrice: string;
+  priceChange: string;
+  priceChangePercent: string;
+  highPrice: string;
+  lowPrice: string;
+  volume: string;
+  quoteVolume: string;
 };
 
-export function openSpotTickerStream(symbols: string[], onTicker: (t: Ticker)=>void) {
-  const streams = symbols.map(s => `${s.toLowerCase()}@ticker`).join('/');
+export type SpotTickerStreamOptions = {
+  onMessage?: (ticker: Ticker) => void;
+  onOpen?: (event: Event) => void;
+  onClose?: (event: CloseEvent) => void;
+  onError?: (event: Event | Error) => void;
+  maxReconnects?: number;
+};
+
+type SpotTickerHandler = (ticker: Ticker) => void;
+
+function normaliseSymbols(input: string | string[]): string[] {
+  if (Array.isArray(input)) return input;
+  if (!input) return [];
+  return [input];
+}
+
+export function openSpotTickerStream(
+  symbolsInput: string | string[],
+  optionsOrHandler: SpotTickerStreamOptions | SpotTickerHandler = {},
+) {
+  const symbols = normaliseSymbols(symbolsInput).filter(Boolean);
+  if (symbols.length === 0) {
+    throw new Error("openSpotTickerStream requires at least one symbol");
+  }
+
+  const options: SpotTickerStreamOptions =
+    typeof optionsOrHandler === "function" ? { onMessage: optionsOrHandler } : optionsOrHandler;
+
+  const onTicker = options.onMessage;
+  const streams = symbols.map((s) => `${s.toLowerCase()}@ticker`).join("/");
   const url = `wss://stream.binance.com:9443/stream?streams=${streams}`;
-  let ws: WebSocket | null = null, tries = 0;
+
+  let ws: WebSocket | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectAttempts = 0;
+  let disposed = false;
+
+  const maxReconnects = options.maxReconnects ?? Infinity;
+
+  const cleanup = () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+  };
 
   const connect = () => {
+    if (disposed) return;
+    cleanup();
     ws = new WebSocket(url);
-    ws.onopen = () => { tries = 0; };
+
+    ws.onopen = (event) => {
+      reconnectAttempts = 0;
+      options.onOpen?.(event);
+    };
+
     ws.onmessage = (ev) => {
       try {
-        const msg = JSON.parse(ev.data as any);
-        const d = (msg && (msg as any).data) || msg;
-        onTicker({
-          symbol: d.s, lastPrice: d.c, priceChange: d.p, priceChangePercent: d.P,
-          highPrice: d.h, lowPrice: d.l, volume: d.v, quoteVolume: d.q
+        const msg = JSON.parse(ev.data as string);
+        const data = (msg && (msg as any).data) || msg;
+        if (!data) return;
+        onTicker?.({
+          symbol: data.s,
+          lastPrice: data.c,
+          priceChange: data.p,
+          priceChangePercent: data.P,
+          highPrice: data.h,
+          lowPrice: data.l,
+          volume: data.v,
+          quoteVolume: data.q,
         });
-      } catch {}
+      } catch (err) {
+        // swallow parse errors but allow consumer to know via error handler
+        options.onError?.(err instanceof Error ? err : new Error("Failed to parse ticker message"));
+      }
     };
-    ws.onclose = () => {
-      const delay = Math.min(30000, 1000 * Math.pow(2, Math.min(++tries, 5)));
-      setTimeout(connect, delay);
+
+    ws.onerror = (event) => {
+      options.onError?.(event);
+    };
+
+    ws.onclose = (event) => {
+      options.onClose?.(event);
+      if (disposed) return;
+      if (reconnectAttempts >= maxReconnects) return;
+
+      const attempt = reconnectAttempts + 1;
+      const delay = Math.min(30000, 1000 * Math.pow(2, Math.min(attempt, 5)));
+
+      reconnectTimer = setTimeout(() => {
+        reconnectAttempts = attempt;
+        connect();
+      }, delay);
     };
   };
 
   connect();
-  return () => ws?.close();
+
+  return () => {
+    disposed = true;
+    cleanup();
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      try {
+        ws.close(1000, "normal");
+      } catch {
+        // ignore
+      }
+    }
+    ws = null;
+  };
 }

--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -220,19 +220,21 @@ export default function Analyse() {
     setPriceData(null);
     if (!networkEnabled) return;
     let active = true;
-    const unsubscribe = openSpotTickerStream([selectedSymbol], (ticker) => {
-      if (!active) return;
-      if ((ticker.symbol || "").toUpperCase() !== selectedSymbol.toUpperCase()) return;
-      setPriceData({
-        symbol: ticker.symbol,
-        lastPrice: ticker.lastPrice,
-        priceChange: ticker.priceChange,
-        priceChangePercent: ticker.priceChangePercent,
-        highPrice: ticker.highPrice,
-        lowPrice: ticker.lowPrice,
-        volume: ticker.volume,
-        quoteVolume: ticker.quoteVolume,
-      });
+    const unsubscribe = openSpotTickerStream(selectedSymbol, {
+      onMessage: (ticker) => {
+        if (!active) return;
+        if ((ticker.symbol || "").toUpperCase() !== selectedSymbol.toUpperCase()) return;
+        setPriceData({
+          symbol: ticker.symbol,
+          lastPrice: ticker.lastPrice,
+          priceChange: ticker.priceChange,
+          priceChangePercent: ticker.priceChangePercent,
+          highPrice: ticker.highPrice,
+          lowPrice: ticker.lowPrice,
+          volume: ticker.volume,
+          quoteVolume: ticker.quoteVolume,
+        });
+      },
     });
     return () => {
       active = false;

--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -214,19 +214,21 @@ export default function Charts() {
   useEffect(() => {
     setPriceData(null);
     let active = true;
-    const unsubscribe = openSpotTickerStream([selectedSymbol], (ticker) => {
-      if (!active) return;
-      if ((ticker.symbol || "").toUpperCase() !== selectedSymbol.toUpperCase()) return;
-      setPriceData({
-        symbol: ticker.symbol,
-        lastPrice: ticker.lastPrice,
-        priceChange: ticker.priceChange,
-        priceChangePercent: ticker.priceChangePercent,
-        highPrice: ticker.highPrice,
-        lowPrice: ticker.lowPrice,
-        volume: ticker.volume,
-        quoteVolume: ticker.quoteVolume,
-      });
+    const unsubscribe = openSpotTickerStream(selectedSymbol, {
+      onMessage: (ticker) => {
+        if (!active) return;
+        if ((ticker.symbol || "").toUpperCase() !== selectedSymbol.toUpperCase()) return;
+        setPriceData({
+          symbol: ticker.symbol,
+          lastPrice: ticker.lastPrice,
+          priceChange: ticker.priceChange,
+          priceChangePercent: ticker.priceChangePercent,
+          highPrice: ticker.highPrice,
+          lowPrice: ticker.lowPrice,
+          volume: ticker.volume,
+          quoteVolume: ticker.quoteVolume,
+        });
+      },
     });
     return () => {
       active = false;


### PR DESCRIPTION
## Summary
- extend the Binance spot ticker stream helper to accept a symbol (or list) plus an options bag with event handlers and reconnect limits
- forward the helper's WebSocket events to the supplied handlers and stop reconnects once the limit is reached
- update Analyse, Charts, and LiveSummary pages to use the new options-style API when subscribing to tickers

## Testing
- npm run check *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68dfdcef67008323ae9ea27e42736dc9