### PR TITLE
Add window gtag type declaration

### DIFF
--- a/client/src/types/global.d.ts
+++ b/client/src/types/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a global ambient declaration so `window.gtag` is typed as an optional function

## Testing
- npm run check *(fails: existing TypeScript errors in the project)*
- node node_modules/vite/bin/vite.js build *(fails: PostCSS plugin missing `../lib/statuses`)*

------
https://chatgpt.com/codex/tasks/task_e_68dfde5a79908323a55965b3e6959cc0