### PR TITLE
Add standalone Express server backend

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,2 @@
+PORT=4000
+ALLOWED_ORIGIN=http://localhost:5173

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "stock-portfolio-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node --watch server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "ws": "^8.17.0"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,67 @@
+import http from "http";
+import express from "express";
+import cors from "cors";
+import dotenv from "dotenv";
+import { WebSocketServer } from "ws";
+
+dotenv.config();
+
+const PORT = Number.parseInt(process.env.PORT ?? "4000", 10);
+const allowedOrigin = process.env.ALLOWED_ORIGIN ?? "*";
+
+const app = express();
+
+app.use(
+  cors({
+    origin:
+      allowedOrigin === "*"
+        ? "*"
+        : allowedOrigin.split(",").map((origin) => origin.trim()).filter(Boolean),
+  }),
+);
+app.use(express.json());
+
+app.get("/", (_req, res) => {
+  res.json({ message: "Stock Portfolio backend is running" });
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.get("/api/time", (_req, res) => {
+  res.json({ now: new Date().toISOString() });
+});
+
+app.post("/api/echo", (req, res) => {
+  res.json({ echo: req.body ?? null });
+});
+
+app.use((req, res) => {
+  res.status(404).json({ message: "Not Found" });
+});
+
+const server = http.createServer(app);
+
+const wss = new WebSocketServer({ noServer: true });
+
+wss.on("connection", (socket) => {
+  socket.on("message", (message) => {
+    socket.send(message.toString());
+  });
+});
+
+server.on("upgrade", (request, socket, head) => {
+  if (request.url !== "/ws") {
+    socket.destroy();
+    return;
+  }
+
+  wss.handleUpgrade(request, socket, head, (websocket) => {
+    wss.emit("connection", websocket, request);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an isolated Express-based server entry point with REST routes and WebSocket echo support
- document backend configuration defaults via .env.example
- configure backend package.json for ESM execution and dependency management

## Testing
- Not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dfe5905c9c8323a935bde607c017e5