### PR TITLE
Route API calls via VITE_API_BASE

### DIFF
--- a/client/src/initApiBase.ts
+++ b/client/src/initApiBase.ts
@@ -1,0 +1,15 @@
+// Reroute relative /api/* calls to the backend specified by VITE_API_BASE.
+const API_BASE = import.meta.env.VITE_API_BASE?.replace(/\/$/, '');
+
+if (typeof window !== 'undefined' && API_BASE) {
+  const origFetch = window.fetch.bind(window);
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    try {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.startsWith('/api/')) {
+        return origFetch(`${API_BASE}${url}`, init);
+      }
+    } catch {}
+    return origFetch(input as any, init);
+  };
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,4 @@
+import "./initApiBase";
 // client/src/main.tsx
 import "./lib/disableLocalWs";
 import React from "react";


### PR DESCRIPTION
## Summary
- add a bootstrap script that rewrites relative /api calls to use the configured VITE_API_BASE backend
- ensure the bootstrap script executes before the rest of the client code

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0388e5e2083239bdd529ba3889a2d