### PR TITLE
Use backend health probe to gate client features

### DIFF
--- a/client/src/hooks/use-backend-health.ts
+++ b/client/src/hooks/use-backend-health.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+
+const API_BASE = (import.meta as any)?.env?.VITE_API_BASE?.replace(/\/$/, "") || "";
+const HEALTH_URL = `${API_BASE || ""}/api/health`;
+
+let cachedStatus: boolean | undefined;
+let pendingProbe: Promise<boolean> | null = null;
+
+async function probeBackend(): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 4000);
+
+  try {
+    const response = await fetch(HEALTH_URL, { signal: controller.signal });
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function ensureProbe(): Promise<boolean> {
+  if (cachedStatus !== undefined) {
+    return Promise.resolve(cachedStatus);
+  }
+
+  if (!pendingProbe) {
+    pendingProbe = probeBackend().then((result) => {
+      cachedStatus = result;
+      return result;
+    }).finally(() => {
+      pendingProbe = null;
+    });
+  }
+
+  return pendingProbe;
+}
+
+export function useBackendHealth(): boolean | null {
+  const [status, setStatus] = useState<boolean | null>(() => {
+    if (cachedStatus === undefined) return null;
+    return cachedStatus;
+  });
+
+  useEffect(() => {
+    let active = true;
+
+    if (cachedStatus !== undefined) {
+      setStatus(cachedStatus);
+      return () => {
+        active = false;
+      };
+    }
+
+    ensureProbe().then((result) => {
+      if (active) {
+        setStatus(result);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return status;
+}


### PR DESCRIPTION
## Summary
- add a shared `useBackendHealth` hook that probes `/api/health` with a timeout and caches the result
- switch the Analyse page to the runtime backend status for banners, UI states, and query/mutation guards
- apply the same runtime backend gating to the Home and Portfolio pages for queries and live websocket behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e03f82c15c83239322c16f2a1f0167