### PR TITLE
Add POST handlers for scanner endpoints

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -85,7 +85,17 @@ app.get("/api/scanner/high-potential", (_req, res) => {
   res.json({ data: [] });
 });
 
+app.post("/api/scanner/high-potential", (_req, res) => {
+  // Expected shape: { data: [{ symbol: string; score: number; reason: string }] }
+  res.json({ data: [] });
+});
+
 app.get("/api/scanner/history", (_req, res) => {
+  // Expected shape: { data: [{ date: string; symbol: string; score: number }] }
+  res.json({ data: [] });
+});
+
+app.post("/api/scanner/history", (_req, res) => {
   // Expected shape: { data: [{ date: string; symbol: string; score: number }] }
   res.json({ data: [] });
 });


### PR DESCRIPTION
## Summary
- add POST handlers for the scanner high-potential and history endpoints that return the expected response shape

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e052408218832382de0beb5a91720e