### PR TITLE
Add scanner scan endpoint

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -134,6 +134,10 @@ app.post("/api/scanner/high-potential", (_req, res) => {
   res.json({ data: [] });
 });
 
+app.post("/api/scanner/scan", (_req, res) => {
+  res.json({ data: [] });
+});
+
 app.get("/api/scanner/history", (_req, res) => {
   // Expected shape: { data: [{ date: string; symbol: string; score: number }] }
   res.json({ data: [] });


### PR DESCRIPTION
## Summary
- add POST /api/scanner/scan endpoint returning an empty data array to align with scanner routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05775931c8323a7a5e10019e378f0