### PR TITLE
Fix WebSocket URL detection for client pages

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -177,9 +177,9 @@ export default function Home() {
   useEffect(() => {
     if (!networkEnabled) return;
     if (typeof window === "undefined") return;
-    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-    const wsBase = API_BASE ? API_BASE.replace(/^http/, "ws") : `${protocol}://${window.location.host}`;
-    const ws = new WebSocket(`${wsBase}/ws`);
+    const apiBase = import.meta.env.VITE_API_BASE || window.location.origin;
+    const wsUrl = apiBase.replace(/^http/, "ws").replace(/\/$/, "") + "/ws";
+    const ws = new WebSocket(wsUrl);
     ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
@@ -191,7 +191,7 @@ export default function Home() {
       ws.send(JSON.stringify({ type: "subscribe", symbol: "ETHUSDT" }));
     };
     return () => ws.close();
-  }, [API_BASE, networkEnabled]);
+  }, [networkEnabled]);
 
   // ---------- Tiles (React Query; disabled on Vercel without API_BASE) ----------
   const { data: port } = useQuery({

--- a/client/src/pages/portfolio.tsx
+++ b/client/src/pages/portfolio.tsx
@@ -91,9 +91,9 @@ export default function Portfolio() {
     if (!networkEnabled) return;
     if (typeof window === "undefined") return;
 
-    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
-    const wsBase = API_BASE ? API_BASE.replace(/^http/, "ws") : `${protocol}://${window.location.host}`;
-    const ws = new WebSocket(`${wsBase}/ws`);
+    const apiBase = import.meta.env.VITE_API_BASE || window.location.origin;
+    const wsUrl = apiBase.replace(/^http/, "ws").replace(/\/$/, "") + "/ws";
+    const ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {
       const symbols = Array.from(new Set(positions.map((p) => p.symbol.trim().toUpperCase())));
@@ -124,7 +124,7 @@ export default function Portfolio() {
     return () => {
       try { ws.close(); } catch {}
     };
-  }, [user, API_BASE, networkEnabled, positionsKey]);
+  }, [user, networkEnabled, positionsKey]);
 
   // Source B: Binance REST polling (covers all symbols reliably)
   const [liveHTTP, setLiveHTTP] = useState<Record<string, number>>({});


### PR DESCRIPTION
## Summary
- update the home page price stream to derive the WebSocket endpoint from the configured API base or current origin
- align the portfolio live price stream with the same WebSocket URL construction and dependency list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0590120b083238c7318ae9b1c91f8