### PR TITLE
Handle stale Analyse scans and render breakdown data

### DIFF
--- a/client/src/components/scanner/trading-view-chart.tsx
+++ b/client/src/components/scanner/trading-view-chart.tsx
@@ -18,6 +18,8 @@ function TradingViewChart({ symbol, interval }: TradingViewChartProps) {
   // Stable id for the widget’s container (prevents widget from “losing” its node between renders)
   const idRef = useRef<string>(`tradingview-${Math.random().toString(36).slice(2)}`);
   const [useFallback, setUseFallback] = useState(false);
+  const normalizedSymbol = (symbol || "").toString().trim().toUpperCase() || "BTCUSDT";
+  const normalizedInterval = (interval || "240").toString();
 
   useEffect(() => {
     setUseFallback(false);
@@ -32,8 +34,8 @@ function TradingViewChart({ symbol, interval }: TradingViewChartProps) {
       try {
         new window.TradingView.widget({
           autosize: true,
-          symbol: `BINANCE:${symbol}`,
-          interval: interval || "240",
+          symbol: `BINANCE:${normalizedSymbol}`,
+          interval: normalizedInterval,
           timezone: "Etc/UTC",
           theme: "dark",
           style: "1",
@@ -79,10 +81,10 @@ function TradingViewChart({ symbol, interval }: TradingViewChartProps) {
         containerRef.current.innerHTML = "";
       }
     };
-  }, [symbol, interval]);
+  }, [normalizedSymbol, normalizedInterval]);
 
   if (useFallback) {
-    return <FallbackChart symbol={symbol} interval={interval || "240"} />;
+    return <FallbackChart symbol={normalizedSymbol} interval={normalizedInterval} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- guard Analyse scans against stale responses by tracking request IDs and only running when the symbol actually changes
- render Breakdown Technicals rows from the scan payload with safe defaults and updated styling
- normalize TradingView widget inputs so the embedded chart always receives a clean symbol/interval

## Testing
- `npm run check` *(fails: missing `@types/node` / `vite/client` definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1296e1e20832397ecfa91e5d68441