### PR TITLE
Refine TradingView widget configuration

### DIFF
--- a/client/src/components/scanner/trading-view-chart.tsx
+++ b/client/src/components/scanner/trading-view-chart.tsx
@@ -1,5 +1,8 @@
 // client/src/components/scanner/trading-view-chart.tsx
 import { useEffect, useRef, useState } from "react";
+
+import { buildTvConfig } from "@/lib/tradingview";
+
 import { FallbackChart } from "./fallback-chart";
 
 interface TradingViewChartProps {
@@ -19,7 +22,7 @@ function TradingViewChart({ symbol, interval }: TradingViewChartProps) {
   const idRef = useRef<string>(`tradingview-${Math.random().toString(36).slice(2)}`);
   const [useFallback, setUseFallback] = useState(false);
   const normalizedSymbol = (symbol || "").toString().trim().toUpperCase() || "BTCUSDT";
-  const normalizedInterval = (interval || "240").toString();
+  const normalizedInterval = (interval || "4h").toString();
 
   useEffect(() => {
     setUseFallback(false);
@@ -32,16 +35,18 @@ function TradingViewChart({ symbol, interval }: TradingViewChartProps) {
       containerRef.current.innerHTML = "";
 
       try {
-        new window.TradingView.widget({
-          autosize: true,
+        const cfg = buildTvConfig({
           symbol: `BINANCE:${normalizedSymbol}`,
-          interval: normalizedInterval,
-          timezone: "Etc/UTC",
+          timeframe: normalizedInterval,
+          containerId: idRef.current,
           theme: "dark",
-          style: "1",
           locale: "en",
+        });
+
+        Object.assign(cfg, {
+          timezone: "Etc/UTC",
+          style: "1",
           allow_symbol_change: true,
-          container_id: idRef.current,
           hide_top_toolbar: false,
           hide_legend: false,
           save_image: false,
@@ -53,6 +58,8 @@ function TradingViewChart({ symbol, interval }: TradingViewChartProps) {
             "MACD@tv-basicstudies",
           ],
         });
+
+        new (window as any).TradingView.widget(cfg);
       } catch (e) {
         console.warn("TradingView widget init failed, using fallback chart", e);
         setUseFallback(true);

--- a/client/src/lib/tradingview.ts
+++ b/client/src/lib/tradingview.ts
@@ -1,0 +1,72 @@
+export const tvIntervalFrom = (tf: string) => {
+  const normalized = String(tf || "").trim();
+  if (!normalized) return "240";
+
+  if (/^\d+$/.test(normalized)) {
+    return normalized;
+  }
+
+  const m = {
+    "15m": "15",
+    "30m": "30",
+    "1h": "60",
+    "2h": "120",
+    "3h": "180",
+    "4h": "240",
+    "6h": "360",
+    "8h": "480",
+    "12h": "720",
+    "1d": "D",
+    "1D": "D",
+    "1day": "D",
+    "1Day": "D",
+    "1w": "W",
+    "1W": "W",
+    "1m": "M",
+    "1M": "M",
+  } as const;
+
+  return m[normalized as keyof typeof m] || "240";
+};
+
+const isPlainObj = (o: any) => !!o && typeof o === "object" && o.constructor === Object;
+const cleanObj = (o: any) => JSON.parse(JSON.stringify(o ?? {}));
+
+export type BuildTvConfigArgs = {
+  symbol: string;
+  timeframe: string;
+  containerId: string;
+  theme?: "dark" | "light";
+  locale?: string;
+  overrides?: Record<string, any>;
+  studiesOverrides?: Record<string, any>;
+};
+
+export const buildTvConfig = ({
+  symbol,
+  timeframe,
+  containerId,
+  theme = "dark",
+  locale = "en",
+  overrides,
+  studiesOverrides,
+}: BuildTvConfigArgs) => {
+  const cfg: Record<string, any> = {
+    symbol: String(symbol || "BTCUSDT").toUpperCase(),
+    interval: tvIntervalFrom(String(timeframe || "4h")),
+    container_id: containerId,
+    autosize: true,
+    theme,
+    locale,
+  };
+
+  if (isPlainObj(overrides) && Object.keys(overrides!).length) {
+    cfg.overrides = cleanObj(overrides);
+  }
+
+  if (isPlainObj(studiesOverrides) && Object.keys(studiesOverrides!).length) {
+    cfg.studies_overrides = cleanObj(studiesOverrides);
+  }
+
+  return cfg;
+};


### PR DESCRIPTION
## Summary
- add a shared TradingView configuration builder with timeframe normalization and option sanitization
- update chart components to build widget configs via the helper and avoid schema warnings

## Testing
- npm run check *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d5f7dd88323b96f537dd78d9934