### PR TITLE
Configure CORS for frontend domains

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -82,18 +82,25 @@ function push(arr, title, value, signal = 'neutral', reason = '') {
 }
 
 const PORT = Number.parseInt(process.env.PORT ?? "4000", 10);
-const allowedOrigin = process.env.ALLOWED_ORIGIN ?? "*";
+const ALLOW_ORIGINS = [
+  "https://stock-portfolio-khaki-nine.vercel.app",
+  "http://localhost:5173",
+];
 
 const app = express();
 
 app.use(
   cors({
-    origin:
-      allowedOrigin === '*'
-        ? '*'
-        : allowedOrigin.split(',').map((origin) => origin.trim()).filter(Boolean),
+    origin: (origin, cb) => {
+      if (!origin) return cb(null, true);
+      return cb(null, ALLOW_ORIGINS.includes(origin));
+    },
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+    credentials: false,
   }),
 );
+app.options("*", cors());
 app.use(express.json());
 
 // ensure memory store exists once


### PR DESCRIPTION
## Summary
- restrict CORS to the production Vercel deployment and local development origin
- explicitly allow standard HTTP methods, headers, and handle preflight requests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e133b9610c8323952f642f2aaa19a9