### PR TITLE
refactor: centralize frontend API client

### DIFF
--- a/client/src/hooks/use-backend-health.ts
+++ b/client/src/hooks/use-backend-health.ts
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
-
-const API_BASE = (import.meta as any)?.env?.VITE_API_BASE?.replace(/\/$/, "") || "";
-const HEALTH_URL = `${API_BASE || ""}/api/health`;
+import { api } from "@/lib/api";
 
 let cachedStatus: boolean | undefined;
 let pendingProbe: Promise<boolean> | null = null;
@@ -11,7 +9,7 @@ async function probeBackend(): Promise<boolean> {
   const timeoutId = setTimeout(() => controller.abort(), 4000);
 
   try {
-    const response = await fetch(HEALTH_URL, { signal: controller.signal });
+    const response = await api("/api/health", { signal: controller.signal });
     return response.ok;
   } catch {
     return false;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,18 @@
+const rawBase = import.meta.env.VITE_API_BASE?.trim();
+// If VITE_API_BASE is set (e.g. during local dev), use it; otherwise use relative paths (Vercel rewrite).
+const base = rawBase ? rawBase.replace(/\/$/, "") : "";
+
+export function api(path: string, init?: RequestInit) {
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  return fetch(url, init);
+}
+
+export async function apiJSON<T = any>(path: string, init?: RequestInit): Promise<T> {
+  const r = await api(path, init);
+  // never throw on non-200; let callers decide, but try to parse JSON
+  try {
+    return await r.json();
+  } catch {
+    return undefined as unknown as T;
+  }
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,6 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 import { getFirebaseIdToken } from "@/lib/firebase";
+import { api } from "@/lib/api";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -28,7 +29,7 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const res = await api(url, {
     method,
     headers: await buildHeaders(data),
     body: data ? JSON.stringify(data) : undefined,
@@ -46,9 +47,8 @@ export const getQueryFn: <T>(options: {
   async ({ queryKey }) => {
     const token = await getFirebaseIdToken();
     const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
-    const res = await fetch(queryKey.join("/") as string, {
-      headers,
-    });
+    const [path] = queryKey as [string, ...unknown[]];
+    const res = await api(path, { headers });
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {
       return null;

--- a/client/src/pages/ai-insights.tsx
+++ b/client/src/pages/ai-insights.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { RefreshCw, Brain, Zap, TrendingUp, Flame } from "lucide-react";
+import { api } from "@/lib/api";
 
 type Insight = {
   title: string;
@@ -77,7 +78,7 @@ export default function AIInsights() {
     mutationFn: async () => {
       // 1) Try your API if it exists
       try {
-        const r = await fetch("/api/ai/insights");
+        const r = await api("/api/ai/insights");
         if (r.ok) {
           return (await r.json()) as { insights: Insight[]; table?: Binance24hr[] };
         }

--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -289,7 +289,7 @@ export default function Analyse() {
       try {
         const res = await apiRequest(
           "POST",
-          `${API_BASE || ""}/api/scanner/scan`,
+          "/api/scanner/scan",
           {
             symbol,
             timeframe: backendTimeframe,

--- a/client/src/pages/gainers.tsx
+++ b/client/src/pages/gainers.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { RefreshCw, TrendingUp, Trophy, Medal, BarChart3 } from "lucide-react";
+import { api } from "@/lib/api";
 
 type GainerData = {
   symbol: string;
@@ -27,7 +28,7 @@ function safeNum(n: unknown, fallback = 0): number {
 async function fetchFromAppAPI(limit: number, isAuthenticated: boolean): Promise<GainerData[] | null> {
   const url = isAuthenticated ? "/api/market/gainers" : `/api/market/gainers?limit=${limit}`;
   try {
-    const res = await fetch(url);
+    const res = await api(url);
     if (!res.ok) return null; // trigger fallback
     const data = await res.json();
     return Array.isArray(data) ? (data as GainerData[]) : null;


### PR DESCRIPTION
## Summary
- add a shared api helper that resolves VITE_API_BASE and exposes api/apiJSON wrappers
- refactor health checks, query helpers, and UI pages to route through the new client instead of manual fetch URLs
- remove the binary favicon placeholder so the frontend no longer ships an unsupported asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e136826e80832382d604458f796a06