### PR TITLE
Update gainers page to show spot USDT data only

### DIFF
--- a/api/market/gainers.ts
+++ b/api/market/gainers.ts
@@ -1,50 +1,35 @@
-import type { VercelRequest, VercelResponse } from "@vercel/node";
+import type { VercelRequest, VercelResponse } from "vercel";
 
-const BINANCE_24H = "https://api.binance.com/api/v3/ticker/24hr";
-
-const clampLimit = (raw: unknown, fallback: number, max = 100): number => {
-  const value = Number(Array.isArray(raw) ? raw[0] : raw);
-  if (!Number.isFinite(value) || value <= 0) return fallback;
-  return Math.max(1, Math.min(Math.floor(value), max));
-};
-
-const toString = (value: unknown): string => {
-  if (typeof value === "string") return value;
-  if (typeof value === "number" && Number.isFinite(value)) return value.toString();
-  return "0";
-};
+const BINANCE = "https://api.binance.com";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
-    const limit = clampLimit(req.query?.limit, 20);
-    const response = await fetch(BINANCE_24H, { cache: "no-store" });
-    if (!response.ok) {
-      return res
-        .status(response.status)
-        .json({ ok: false, error: `binance_${response.status}`, detail: await response.text() });
+    const exInfo = await fetch(`${BINANCE}/api/v3/exchangeInfo?permissions=SPOT`).then((r) => r.json());
+
+    const spotUSDT = new Set<string>();
+    for (const s of exInfo.symbols ?? []) {
+      if (s.status === "TRADING" && s.isSpotTradingAllowed && s.quoteAsset === "USDT") {
+        spotUSDT.add(s.symbol);
+      }
     }
 
-    const list: any[] = await response.json();
-    const sorted = list
-      .filter((row: any) => typeof row?.symbol === "string" && row.symbol.endsWith("USDT"))
-      .map((row: any) => ({
-        symbol: String(row.symbol),
-        price: toString(row.lastPrice ?? row.weightedAvgPrice ?? "0"),
-        priceChange: toString(row.priceChange ?? "0"),
-        priceChangePercent: toString(row.priceChangePercent ?? "0"),
-        change24h: toString(row.priceChangePercent ?? "0"),
-        highPrice: toString(row.highPrice ?? "0"),
-        lowPrice: toString(row.lowPrice ?? "0"),
-        volume: toString(row.volume ?? "0"),
-        quoteVolume: toString(row.quoteVolume ?? "0"),
+    const stats: any[] = await fetch(`${BINANCE}/api/v3/ticker/24hr`).then((r) => r.json());
+
+    const rows = stats
+      .filter((t) => spotUSDT.has(t.symbol))
+      .map((t) => ({
+        symbol: t.symbol,
+        price: Number(t.lastPrice),
+        changePct: Number(t.priceChangePercent),
+        volume: Number(t.quoteVolume),
+        high: Number(t.highPrice),
+        low: Number(t.lowPrice),
       }))
-      .sort((a, b) => Number(b.priceChangePercent) - Number(a.priceChangePercent));
+      .sort((a, b) => b.changePct - a.changePct);
 
-    const trimmed = sorted.slice(0, limit);
-
-    res.setHeader("Cache-Control", "s-maxage=30, stale-while-revalidate=60");
-    return res.status(200).json(trimmed);
-  } catch (error: any) {
-    return res.status(500).json({ ok: false, error: error?.message || "internal_error" });
+    res.status(200).json({ rows });
+  } catch (err: any) {
+    console.error("gainers spot error:", err);
+    res.status(500).json({ error: "Failed to load gainers" });
   }
 }


### PR DESCRIPTION
## Summary
- replace the gainers page with a scrollable table view featuring rank, price formatting, colour-coded changes, and analyse links while removing the top cards
- update the gainers API to query Binance spot exchange info and return only SPOT USDT pairs with numeric fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a447c3408323811f441923f8825f