### PR TITLE
Refine gainers API payload for SPOT USDT pairs

### DIFF
--- a/api/market/gainers.ts
+++ b/api/market/gainers.ts
@@ -1,112 +1,97 @@
 import type { VercelRequest, VercelResponse } from "vercel";
 
 const BINANCE = "https://api.binance.com";
-// Exclude leveraged tokens / ETFs
+
+// Exclude leveraged/fan/ETF style tokens by suffix
 const EXCLUDE_REGEX = /(UP|DOWN|BULL|BEAR|\d+L|\d+S)USDT$/;
 
-const MIN_QUOTE_VOL_USDT = 1_000_000; // $1M in quote volume (USDT for *USDT pairs)
-const FALLBACK_MIN_VOL = 300_000; // fallback if list ends up too small
-const MIN_ROWS_TARGET = 60; // ensure we still render a useful list
+// Volume floors (progressively relaxed so we never return empty)
+const FLOORS = [1_000_000, 300_000, 50_000, 1]; // USDT quote volume
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+async function getJson(url: string) {
+  const r = await fetch(url, { headers: { "User-Agent": "stock-portfolio/1.0" } });
+  if (!r.ok) throw new Error(`${url} -> ${r.status}`);
+  return r.json();
+}
+
+export default async function handler(_req: VercelRequest, res: VercelResponse) {
   try {
-    // --- A) SPOT allowlist (authoritative) ---
-    // Use permissions=SPOT to avoid symbols with no spot trading.
-    const exInfoRes = await fetch(`${BINANCE}/api/v3/exchangeInfo?permissions=SPOT`);
-    if (!exInfoRes.ok) {
-      throw new Error(`exchangeInfo failed: ${exInfoRes.status}`);
-    }
-
-    const exInfo = await exInfoRes.json();
-
-    if (!exInfo || !Array.isArray(exInfo.symbols)) {
-      throw new Error("exchangeInfo malformed");
+    // --- Build SPOT-USDT allowlist (try permissions=SPOT first, then full) ---
+    let exInfo: any;
+    try {
+      exInfo = await getJson(`${BINANCE}/api/v3/exchangeInfo?permissions=SPOT`);
+    } catch {
+      exInfo = await getJson(`${BINANCE}/api/v3/exchangeInfo`);
     }
 
     const allowUSDT = new Set<string>();
-    for (const s of exInfo.symbols) {
-      const isTrading = s.status === "TRADING";
-      const isUSDT = s.quoteAsset === "USDT";
-      if (isTrading && isUSDT && !EXCLUDE_REGEX.test(s.symbol)) {
+    for (const s of exInfo?.symbols ?? []) {
+      const hasSpot = s?.permissions?.includes?.("SPOT") || s?.isSpotTradingAllowed === true;
+      if (
+        hasSpot &&
+        s?.status === "TRADING" &&
+        s?.quoteAsset === "USDT" &&
+        typeof s?.symbol === "string" &&
+        !EXCLUDE_REGEX.test(s.symbol)
+      ) {
         allowUSDT.add(s.symbol);
       }
     }
 
-    // --- B) 24h stats (must be array) ---
-    const statsRes = await fetch(`${BINANCE}/api/v3/ticker/24hr`);
-    if (!statsRes.ok) {
-      throw new Error(`ticker/24hr failed: ${statsRes.status}`);
-    }
+    // --- 24h stats (array) ---
+    const tickers: any = await getJson(`${BINANCE}/api/v3/ticker/24hr`);
+    if (!Array.isArray(tickers)) throw new Error("ticker/24hr not array");
 
-    const stats = await statsRes.json();
-    if (!Array.isArray(stats)) {
-      // Rate limit or error object – surface a controlled error
-      throw new Error(`ticker/24hr not array: ${JSON.stringify(stats).slice(0, 120)}`);
-    }
+    // --- Join + safe parse ---
+    const toNum = (v: any) => {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : 0;
+    };
 
-    // --- C) Join, parse safely, drop dead rows ---
-    const rowsRaw = stats
+    let rows = tickers
       .filter((t: any) => allowUSDT.has(t.symbol))
-      .map((t: any) => {
-        const num = (v: any) => {
-          const n = Number(v);
-          return Number.isFinite(n) ? n : 0;
-        };
-        return {
+      .map((t: any) => ({
+        symbol: t.symbol,
+        price: toNum(t.lastPrice),
+        changePct: toNum(t.priceChangePercent),
+        volume: toNum(t.quoteVolume),
+        high: toNum(t.highPrice),
+        low: toNum(t.lowPrice),
+      }));
+
+    // Fallback: if allowlist unexpectedly tiny, derive from tickers to avoid empties
+    if (rows.length === 0 && allowUSDT.size < 50) {
+      rows = tickers
+        .filter((t: any) => /USDT$/.test(t.symbol) && !EXCLUDE_REGEX.test(t.symbol))
+        .map((t: any) => ({
           symbol: t.symbol,
-          price: num(t.lastPrice),
-          changePct: num(t.priceChangePercent),
-          volume: num(t.quoteVolume), // USDT volume
-          high: num(t.highPrice),
-          low: num(t.lowPrice),
-        };
-      });
-
-    const nonZero = rowsRaw.filter((r) => r.price > 0 && r.volume > 0);
-
-    // primary: $1M+ volume
-    let filtered = nonZero.filter((r) => r.volume >= MIN_QUOTE_VOL_USDT);
-
-    // fallback: if too few, relax to $300k to avoid empty UI during quiet hours
-    let volumeThresholdUsed = MIN_QUOTE_VOL_USDT;
-    if (filtered.length < MIN_ROWS_TARGET) {
-      filtered = nonZero.filter((r) => r.volume >= FALLBACK_MIN_VOL);
-      volumeThresholdUsed = FALLBACK_MIN_VOL;
+          price: toNum(t.lastPrice),
+          changePct: toNum(t.priceChangePercent),
+          volume: toNum(t.quoteVolume),
+          high: toNum(t.highPrice),
+          low: toNum(t.lowPrice),
+        }));
     }
 
-    const top = filtered
-      .sort((a, b) => b.changePct - a.changePct)
-      .slice(0, 120); // still capped to top ~100–150
+    // Kill zero rows, apply progressive volume floors so we always have data
+    rows = rows.filter(r => r.price > 0 && r.volume > 0 && r.high > 0 && r.low > 0);
+    let filtered: typeof rows = [];
+    for (const floor of FLOORS) {
+      filtered = rows.filter(r => r.volume >= floor);
+      if (filtered.length >= 20) break; // good enough for the UI
+    }
+    if (filtered.length === 0) filtered = rows; // absolute fallback
 
-    const meta = undefined;
+    // Sort and cap (keep the list light)
+    const top = filtered.sort((a, b) => b.changePct - a.changePct).slice(0, 120);
 
-    // Short CDN cache so we don’t hammer Binance
+    // Exact payload shape the FE expects — NO extra keys
     res.setHeader("Cache-Control", "s-maxage=30, stale-while-revalidate=60");
-    res.status(200).json({
-      rows: top,
-      meta: {
-        ...(meta || {}),
-        volumeThresholdUsed,
-        counts: {
-          nonZero: nonZero.length,
-          filtered: filtered.length,
-          top: top.length,
-        },
-      },
-    });
-
-    // Debug counters (visible in logs)
-    console.log("gainers counts:", {
-      allowUSDT: allowUSDT.size,
-      stats: stats.length,
-      rowsRaw: rowsRaw.length,
-      nonZero: nonZero.length,
-      filtered: filtered.length,
-      top: top.length,
-      volumeThresholdUsed,
-    });
-  } catch (err: any) {
-    console.error("gainers spot error:", err?.message || err);
-    res.status(200).json({ rows: [] }); // return empty payload (client handles “No data”)
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.status(200).json({ rows: top });
+  } catch (e) {
+    // Return a valid (empty) shape rather than an error object
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.status(200).json({ rows: [] });
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the gainers endpoint to source SPOT-permitted USDT symbols via exchangeInfo with a fallback
- sanitize ticker data, progressively relax volume floors, and cap the sorted list
- return the exact `{ rows: [...] }` payload with short caching and empty-shape error handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b8136ed083238ba141211f8653da