### PR TITLE
Rebuild high potential scanner with new API and UI

### DIFF
--- a/api/scanner/high-potential.ts
+++ b/api/scanner/high-potential.ts
@@ -1,32 +1,77 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { technicalIndicators } from "../services/technicalIndicators";
-import { getStorage, getUserId, readJsonBody } from "../_lib/serverless";
+import { highPotentialScanner, normalizeHighPotentialFilters } from "../../server/highPotential/scanner";
+import type { HighPotentialFilters } from "@shared/high-potential/types";
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function toBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    if (value.trim().length === 0) return undefined;
+    return !["0", "false", "no"].includes(value.toLowerCase());
+  }
+  if (typeof value === "number") return value !== 0;
+  return undefined;
+}
+
+function extractFilters(req: VercelRequest): HighPotentialFilters {
+  const partial: Partial<HighPotentialFilters> = {};
+
+  const bodySource = req.method === "POST" ? req.body : undefined;
+  const body = typeof bodySource === "string"
+    ? (JSON.parse(bodySource) as Record<string, unknown>)
+    : (bodySource as Record<string, unknown> | undefined);
+
+  if (body && typeof body === "object") {
+    if (typeof body.timeframe === "string") partial.timeframe = body.timeframe as HighPotentialFilters["timeframe"];
+    const bodyMinVol = toNumber(body.minVolUSD);
+    if (bodyMinVol !== undefined) partial.minVolUSD = bodyMinVol;
+    const bodyExclude = toBoolean(body.excludeLeveraged);
+    if (bodyExclude !== undefined) partial.excludeLeveraged = bodyExclude;
+    if (Array.isArray(body.capRange)) {
+      const [min, max] = body.capRange;
+      const capMin = toNumber(min);
+      const capMax = toNumber(max);
+      if (capMin !== undefined || capMax !== undefined) {
+        partial.capRange = [capMin ?? 0, capMax ?? capMin ?? 0];
+      }
+    }
+  }
+
+  const query = req.query ?? {};
+  if (typeof query.timeframe === "string") {
+    partial.timeframe = query.timeframe as HighPotentialFilters["timeframe"];
+  }
+  const queryMinVol = toNumber(query.minVolUSD);
+  if (queryMinVol !== undefined) partial.minVolUSD = queryMinVol;
+  const queryExclude = toBoolean(query.excludeLeveraged);
+  if (queryExclude !== undefined) partial.excludeLeveraged = queryExclude;
+  const capMin = toNumber(query.capMin);
+  const capMax = toNumber(query.capMax);
+  if (capMin !== undefined || capMax !== undefined) {
+    const existing = partial.capRange ?? [capMin ?? 0, capMax ?? 0];
+    partial.capRange = [capMin ?? existing[0], capMax ?? existing[1]];
+  }
+
+  return normalizeHighPotentialFilters(partial);
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  if (req.method !== "POST") {
-    res.setHeader("Allow", "POST");
+  if (req.method !== "GET" && req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
     return res.status(405).json({ message: "Method Not Allowed" });
   }
 
   try {
-    const body = (await readJsonBody<Record<string, unknown>>(req)) ?? {};
-    const filters = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
-
-    const results = await technicalIndicators.scanHighPotential(filters as any);
-
-    const storage = await getStorage();
-    const userId = await getUserId(req);
-
-    await storage.createScanHistory({
-      userId,
-      scanType: "high_potential",
-      filters,
-      results,
-    });
-
-    return res.status(200).json(results);
+    const filters = extractFilters(req);
+    const data = await highPotentialScanner.getScan(filters);
+    return res.status(200).json(data);
   } catch (error) {
     console.error("/api/scanner/high-potential error", error);
-    return res.status(500).json({ message: "Failed to scan high potential symbols" });
+    return res.status(500).json({ message: "Failed to load high potential data" });
   }
 }

--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -26,6 +26,7 @@ import { asArray, asString } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 import { toBinance } from "@/lib/symbols";
 import { useRoute, useLocation } from "wouter";
+import type { HighPotentialResponse } from "@shared/high-potential/types";
 import {
   Activity,
   BarChart3,
@@ -84,14 +85,6 @@ interface ScanHistoryItem {
   filters?: { symbol?: string; timeframe?: string } | null;
   results?: ScanResult | null;
   createdAt?: number | string | null;
-}
-
-interface HighPotentialFilters {
-  timeframe?: string;
-  minScore?: number;
-  minVolume?: string;
-  excludeStablecoins?: boolean;
-  limit?: number;
 }
 
 const DEFAULT_TIMEFRAME = "240"; // 4h
@@ -347,16 +340,23 @@ export default function Charts() {
     enabled: isAuthenticated,
     staleTime: 10 * 60_000,
     queryFn: async () => {
-      const payload: HighPotentialFilters = {
+      const params = new URLSearchParams({
         timeframe: timeframeConfig?.backend || "4h",
-        minScore: 18,
-        minVolume: "1M",
-        excludeStablecoins: true,
-        limit: 8,
-      };
-      const res = await apiRequest("POST", "/api/scanner/high-potential", payload);
-      const data = (await res.json()) as ScanResult[];
-      return Array.isArray(data) ? data.slice(0, 6) : [];
+        minVolUSD: "2000000",
+        capMin: "0",
+        capMax: "2000000000",
+        excludeLeveraged: "true",
+      });
+      const res = await apiRequest("GET", `/api/high-potential?${params.toString()}`);
+      const payload = (await res.json()) as HighPotentialResponse;
+      if (!payload || !Array.isArray(payload.top)) return [];
+      return payload.top.slice(0, 6).map((coin) => ({
+        symbol: coin.symbol,
+        price: coin.price,
+        indicators: {},
+        totalScore: coin.score,
+        recommendation: confidenceToRecommendation(coin.confidence),
+      } satisfies ScanResult));
     },
   });
 
@@ -977,6 +977,19 @@ function getScoreColor(score: number) {
   if (score <= -10) return "text-red-600";
   if (score <= -5) return "text-red-500";
   return "text-yellow-500";
+}
+
+function confidenceToRecommendation(confidence: string): ScanResult["recommendation"] {
+  switch (confidence) {
+    case "High":
+      return "strong_buy";
+    case "Medium":
+      return "buy";
+    case "Watch":
+      return "hold";
+    default:
+      return "hold";
+  }
 }
 
 function getRecommendationColor(recommendation: string) {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -7,6 +7,7 @@ import { useBackendHealth } from "@/hooks/use-backend-health";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { api } from "@/lib/api";
+import type { HighPotentialResponse } from "@shared/high-potential/types";
 import {
   TrendingUp,
   BarChart3,
@@ -84,13 +85,17 @@ async function qPortfolioSummary(): Promise<{ totalValue: number | null; totalPn
 }
 
 async function qHighPotentialCount(): Promise<{ count: number | null; ts: number }> {
-  const post = await safeJson<any>("/api/scanner/high-potential", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({}),
+  const params = new URLSearchParams({
+    timeframe: "4h",
+    minVolUSD: "2000000",
+    capMin: "0",
+    capMax: "2000000000",
+    excludeLeveraged: "true",
   });
-  if (Array.isArray(post)) return { count: post.length, ts: Date.now() };
-  if (post && Array.isArray(post.results)) return { count: post.results.length, ts: Date.now() };
+  const response = await safeJson<HighPotentialResponse>(`/api/high-potential?${params.toString()}`);
+  if (response && Array.isArray(response.top)) {
+    return { count: response.top.length, ts: Date.now() };
+  }
   return { count: null, ts: Date.now() };
 }
 

--- a/server/highPotential/scanner.ts
+++ b/server/highPotential/scanner.ts
@@ -1,0 +1,917 @@
+import { setTimeout as delay } from "node:timers/promises";
+import type { Request } from "express";
+import { binanceService } from "../services/binanceService";
+import type {
+  HighPotentialCoin,
+  HighPotentialFilters,
+  HighPotentialResponse,
+  HighPotentialSocial,
+  HighPotentialTimeframe,
+} from "@shared/high-potential/types";
+
+interface BinanceTicker24h {
+  symbol: string;
+  lastPrice: string;
+  priceChangePercent: string;
+  quoteVolume: string;
+}
+
+interface BinanceBookTicker {
+  symbol: string;
+  bidPrice: string;
+  askPrice: string;
+}
+
+interface BinanceExchangeSymbol {
+  symbol: string;
+  baseAsset: string;
+  quoteAsset: string;
+  status: string;
+}
+
+interface CoinGeckoMarketItem {
+  id: string;
+  symbol: string;
+  name: string;
+  market_cap: number;
+  market_cap_rank: number | null;
+}
+
+interface SocialCacheEntry {
+  data: HighPotentialSocial;
+  expiresAt: number;
+  updatedAt: number;
+}
+
+interface ScanCacheEntry {
+  filtersKey: string;
+  data: HighPotentialResponse;
+  expiresAt: number;
+}
+
+const TEN_MINUTES = 10 * 60 * 1000;
+const EXCHANGE_CACHE_MS = 60 * 60 * 1000;
+const MARKET_CACHE_MS = 10 * 60 * 1000;
+const CRYPTOPANIC_ENDPOINT = "https://cryptopanic.com/api/v1/posts/";
+const CRYPTOPANIC_SPAM_PATTERNS = [
+  /airdrop\s+claim/i,
+  /giveaway/i,
+  /win\s*\$/i,
+  /ref\s+link/i,
+];
+
+const STABLE_BASE_ASSETS = new Set([
+  "USDT",
+  "USDC",
+  "BUSD",
+  "DAI",
+  "TUSD",
+  "FDUSD",
+  "USDP",
+  "EUR",
+  "GBP",
+]);
+
+const LEVERAGED_KEYWORDS = [
+  "UP",
+  "DOWN",
+  "3L",
+  "3S",
+  "4L",
+  "4S",
+  "5L",
+  "5S",
+  "BULL",
+  "BEAR",
+  "PERP",
+];
+
+const DEFAULT_FILTERS: HighPotentialFilters = {
+  timeframe: "4h",
+  minVolUSD: 2_000_000,
+  excludeLeveraged: true,
+  capRange: [0, 2_000_000_000],
+};
+
+const TIMEFRAME_TO_BINANCE: Record<HighPotentialTimeframe, string> = {
+  "1h": "1h",
+  "4h": "4h",
+  "1d": "1d",
+};
+
+const TIMEFRAME_KLINE_LIMIT = 240;
+const INTRA_VOLUME_LOOKBACK = 30;
+const RESISTANCE_LOOKBACK = 20;
+const RSI_PERIOD = 14;
+const MACD_FAST = 12;
+const MACD_SLOW = 26;
+const MACD_SIGNAL = 9;
+const ADX_PERIOD = 14;
+const EMA_FAST = 20;
+const EMA_MED = 50;
+const EMA_SLOW = 200;
+
+const COINGECKO_PAGES = 2; // fetch top 500 markets
+
+const STATIC_ALIAS_SEEDS: Record<string, string[]> = {
+  BTC: ["Bitcoin"],
+  ETH: ["Ethereum"],
+  BNB: ["BNB", "Binance Coin"],
+  SOL: ["Solana"],
+  AVAX: ["Avalanche"],
+  INJ: ["Injective"],
+  RNDR: ["Render", "Render Token"],
+  HBAR: ["Hedera", "Hedera Hashgraph"],
+  ADA: ["Cardano"],
+  XRP: ["XRP", "Ripple"],
+  DOGE: ["Dogecoin"],
+  MATIC: ["Polygon"],
+  DOT: ["Polkadot"],
+  ATOM: ["Cosmos"],
+  APT: ["Aptos"],
+  SUI: ["Sui"],
+  ARB: ["Arbitrum"],
+  OP: ["Optimism"],
+  NEAR: ["NEAR Protocol"],
+  FTM: ["Fantom"],
+  SEI: ["Sei"],
+  TIA: ["Celestia"],
+  MEME: ["Memecoin (MEME)"],
+  PEPE: ["Pepe", "Pepe Coin"],
+  WIF: ["dogwifhat", "WIF"],
+};
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function normalizeHighPotentialFilters(
+  input: Partial<HighPotentialFilters> | undefined,
+): HighPotentialFilters {
+  const timeframeRaw = input?.timeframe ?? DEFAULT_FILTERS.timeframe;
+  const timeframe: HighPotentialTimeframe =
+    timeframeRaw === "1h" || timeframeRaw === "4h" || timeframeRaw === "1d"
+      ? timeframeRaw
+      : DEFAULT_FILTERS.timeframe;
+  const minVolUSD = Math.max(0, toNumber(input?.minVolUSD, DEFAULT_FILTERS.minVolUSD));
+  const excludeLeveraged = Boolean(input?.excludeLeveraged ?? DEFAULT_FILTERS.excludeLeveraged);
+  const capRangeInput = Array.isArray(input?.capRange)
+    ? input?.capRange
+    : DEFAULT_FILTERS.capRange;
+  const capMin = Math.max(0, toNumber(capRangeInput?.[0], DEFAULT_FILTERS.capRange[0]));
+  const capMax = Math.max(capMin, toNumber(capRangeInput?.[1], DEFAULT_FILTERS.capRange[1]));
+  return {
+    timeframe,
+    minVolUSD,
+    excludeLeveraged,
+    capRange: [capMin, capMax],
+  };
+}
+
+function ema(values: number[], period: number): number[] {
+  if (!values.length) return [];
+  const k = 2 / (period + 1);
+  const out: number[] = [];
+  let prev = values[0];
+  out.push(prev);
+  for (let i = 1; i < values.length; i++) {
+    const cur = values[i] * k + prev * (1 - k);
+    out.push(cur);
+    prev = cur;
+  }
+  return out;
+}
+
+function rsi(values: number[], period = RSI_PERIOD): number[] {
+  if (values.length <= period) return [];
+  const gains: number[] = [];
+  const losses: number[] = [];
+  for (let i = 1; i < values.length; i++) {
+    const diff = values[i] - values[i - 1];
+    gains.push(diff > 0 ? diff : 0);
+    losses.push(diff < 0 ? -diff : 0);
+  }
+  let avgGain = gains.slice(0, period).reduce((sum, g) => sum + g, 0) / period;
+  let avgLoss = losses.slice(0, period).reduce((sum, l) => sum + l, 0) / period;
+  const result: number[] = [];
+  result.push(avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss));
+  for (let i = period; i < gains.length; i++) {
+    avgGain = (avgGain * (period - 1) + gains[i]) / period;
+    avgLoss = (avgLoss * (period - 1) + losses[i]) / period;
+    result.push(avgLoss === 0 ? 100 : 100 - 100 / (1 + avgGain / avgLoss));
+  }
+  return result;
+}
+
+function macd(values: number[], fast = MACD_FAST, slow = MACD_SLOW, signal = MACD_SIGNAL) {
+  if (!values.length) {
+    return { macd: [] as number[], signal: [] as number[], histogram: [] as number[] };
+  }
+  const fastEma = ema(values, fast);
+  const slowEma = ema(values, slow);
+  const macdLine: number[] = [];
+  const offset = fastEma.length - slowEma.length;
+  for (let i = 0; i < slowEma.length; i++) {
+    macdLine.push(fastEma[i + offset] - slowEma[i]);
+  }
+  const signalLine = ema(macdLine, signal);
+  const hist: number[] = [];
+  const signalOffset = macdLine.length - signalLine.length;
+  for (let i = 0; i < signalLine.length; i++) {
+    hist.push(macdLine[i + signalOffset] - signalLine[i]);
+  }
+  return {
+    macd: macdLine.slice(macdLine.length - signalLine.length),
+    signal: signalLine,
+    histogram: hist,
+  };
+}
+
+function adx(highs: number[], lows: number[], closes: number[], period = ADX_PERIOD) {
+  if (highs.length !== lows.length || highs.length !== closes.length) {
+    return { adx: [] as number[], plusDI: [] as number[], minusDI: [] as number[] };
+  }
+  if (highs.length < period + 1) {
+    return { adx: [], plusDI: [], minusDI: [] };
+  }
+  const tr: number[] = [];
+  const plusDM: number[] = [];
+  const minusDM: number[] = [];
+  for (let i = 1; i < highs.length; i++) {
+    const high = highs[i];
+    const low = lows[i];
+    const prevClose = closes[i - 1];
+    const trueRange = Math.max(high - low, Math.abs(high - prevClose), Math.abs(low - prevClose));
+    tr.push(trueRange);
+    const upMove = high - highs[i - 1];
+    const downMove = lows[i - 1] - low;
+    plusDM.push(upMove > downMove && upMove > 0 ? upMove : 0);
+    minusDM.push(downMove > upMove && downMove > 0 ? downMove : 0);
+  }
+  const smooth = (arr: number[]) => {
+    const result: number[] = [];
+    let sum = arr.slice(0, period).reduce((acc, cur) => acc + cur, 0);
+    result.push(sum);
+    for (let i = period; i < arr.length; i++) {
+      sum = sum - sum / period + arr[i];
+      result.push(sum);
+    }
+    return result;
+  };
+  const trSmooth = smooth(tr);
+  const plusSmooth = smooth(plusDM);
+  const minusSmooth = smooth(minusDM);
+  const plusDI: number[] = [];
+  const minusDI: number[] = [];
+  const dx: number[] = [];
+  for (let i = 0; i < trSmooth.length; i++) {
+    const trVal = trSmooth[i];
+    const p = trVal === 0 ? 0 : (plusSmooth[i] / trVal) * 100;
+    const m = trVal === 0 ? 0 : (minusSmooth[i] / trVal) * 100;
+    plusDI.push(p);
+    minusDI.push(m);
+    const denom = p + m;
+    dx.push(denom === 0 ? 0 : (Math.abs(p - m) / denom) * 100);
+  }
+  const adxValues: number[] = [];
+  let adxAvg = dx.slice(0, period).reduce((acc, cur) => acc + cur, 0) / period;
+  adxValues.push(adxAvg);
+  for (let i = period; i < dx.length; i++) {
+    adxAvg = (adxAvg * (period - 1) + dx[i]) / period;
+    adxValues.push(adxAvg);
+  }
+  return {
+    adx: adxValues,
+    plusDI: plusDI.slice(plusDI.length - adxValues.length),
+    minusDI: minusDI.slice(minusDI.length - adxValues.length),
+  };
+}
+
+function highest(values: number[], lookback: number): number {
+  if (!values.length) return 0;
+  const slice = values.slice(-lookback);
+  return slice.reduce((max, cur) => (cur > max ? cur : max), slice[0] ?? 0);
+}
+
+function average(values: number[]): number {
+  if (!values.length) return 0;
+  const sum = values.reduce((acc, cur) => acc + cur, 0);
+  return sum / values.length;
+}
+
+function ratio(numerator: number, denominator: number): number {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) {
+    return 0;
+  }
+  return numerator / denominator;
+}
+
+function computeConfidence(score: number): "High" | "Medium" | "Watch" | "Low" {
+  if (score >= 75) return "High";
+  if (score >= 60) return "Medium";
+  if (score >= 50) return "Watch";
+  return "Low";
+}
+interface CoinComputationContext {
+  rsiValue: number;
+  rsiRising: boolean;
+  volumeRatio: number;
+  intraVolumeRatio: number;
+  macdHistogram: number;
+  macdCrossBullishRecent: boolean;
+  adxValue: number;
+  plusDI: number;
+  minusDI: number;
+  ema20: number;
+  ema50: number;
+  ema200: number;
+  emaCrossRecent: boolean;
+  price: number;
+  distancePct: number;
+  vol24h: number;
+  spreadPct: number;
+  marketCap: number;
+  social: HighPotentialSocial;
+  headlineDelta: number;
+}
+
+function scoreMomentum(ctx: CoinComputationContext): number {
+  let rsiScore = 0;
+  if (ctx.rsiRising) {
+    if (ctx.rsiValue >= 35 && ctx.rsiValue <= 45) rsiScore = 10;
+    else if (ctx.rsiValue > 45 && ctx.rsiValue <= 55) rsiScore = 8;
+    else if (ctx.rsiValue > 55 && ctx.rsiValue <= 65) rsiScore = 6;
+  }
+
+  const macdScore = (ctx.macdCrossBullishRecent ? 8 : 0) + (ctx.macdHistogram > 0 ? 4 : 0);
+
+  let adxScore = 0;
+  if (ctx.plusDI > ctx.minusDI) {
+    if (ctx.adxValue >= 18 && ctx.adxValue <= 35) adxScore = 8;
+    else if (ctx.adxValue >= 14 && ctx.adxValue < 18) adxScore = 4;
+  }
+
+  return rsiScore + macdScore + adxScore;
+}
+
+function scoreVolume(ctx: CoinComputationContext): number {
+  const { volumeRatio, intraVolumeRatio } = ctx;
+  let dayRatioScore = 0;
+  if (volumeRatio >= 3) dayRatioScore = 15;
+  else if (volumeRatio >= 2) dayRatioScore = 10;
+  else if (volumeRatio >= 1.5) dayRatioScore = 6;
+
+  let intraScore = 0;
+  if (intraVolumeRatio >= 2.5) intraScore = 10;
+  else if (intraVolumeRatio >= 1.8) intraScore = 7;
+  else if (intraVolumeRatio >= 1.3) intraScore = 4;
+
+  return dayRatioScore + intraScore;
+}
+
+function scoreBreakout(ctx: CoinComputationContext): number {
+  const { distancePct, price, ema20, ema50 } = ctx;
+  let distanceScore = 0;
+  if (distancePct <= 0) distanceScore = 12;
+  else if (distancePct <= 1) distanceScore = 10;
+  else if (distancePct <= 2.5) distanceScore = 7;
+  else if (distancePct <= 4) distanceScore = 3;
+
+  let emaScore = 0;
+  if (price >= ema20 && ema20 >= ema50) emaScore += 5;
+  if (ctx.emaCrossRecent) emaScore += 3;
+  if (emaScore > 8) emaScore = 8;
+
+  return distanceScore + emaScore;
+}
+
+function scoreMarketCap(marketCap: number): number {
+  if (marketCap < 100_000_000) return 10;
+  if (marketCap < 500_000_000) return 7;
+  if (marketCap < 2_000_000_000) return 4;
+  return 0;
+}
+
+function scoreSocial(ctx: CoinComputationContext): number {
+  const { social, headlineDelta } = ctx;
+  let balanceScore = 0;
+  if (headlineDelta >= 3) balanceScore = 6;
+  else if (headlineDelta >= 1) balanceScore = 4;
+  else if (headlineDelta === 0) balanceScore = 2;
+
+  let engagementScore = 0;
+  if (social.avgVoteDelta >= 5) engagementScore = 4;
+  else if (social.avgVoteDelta >= 2) engagementScore = 2;
+  else if (social.avgVoteDelta >= 0) engagementScore = 1;
+
+  return balanceScore + engagementScore;
+}
+
+function scoreQuality(ctx: CoinComputationContext): number {
+  let score = 0;
+  if (ctx.vol24h >= 2_000_000) score += 2;
+  if (ctx.spreadPct <= 0.15) score += 1;
+  score += 2; // clean pair (leveraged/stable excluded during filtering)
+  return score;
+}
+
+function assignBucket(ctx: CoinComputationContext): HighPotentialCoin["bucket"] {
+  const { rsiValue, rsiRising, volumeRatio, macdHistogram, adxValue, distancePct } = ctx;
+  if (distancePct <= 2.5 && volumeRatio >= 1.5) return "Breakout Zone";
+  if (rsiValue >= 30 && rsiValue <= 45 && rsiRising && volumeRatio >= 1.3) return "Oversold Recovery";
+  if (rsiValue >= 50 && rsiValue <= 65 && rsiRising && macdHistogram > 0 && adxValue >= 18) {
+    return "Strong Momentum";
+  }
+  return null;
+}
+
+function calcSpreadPct(ticker: BinanceBookTicker | null): number {
+  if (!ticker) return Infinity;
+  const bid = toNumber(ticker.bidPrice);
+  const ask = toNumber(ticker.askPrice);
+  if (!bid || !ask) return Infinity;
+  return ((ask - bid) / ask) * 100;
+}
+
+function coinKey(filters: HighPotentialFilters): string {
+  return JSON.stringify(filters);
+}
+
+type AliasBundle = {
+  query: string;
+  aliases: string[];
+};
+
+function buildAliasBundle(symbol: string, name?: string | null): AliasBundle {
+  const base = symbol.toUpperCase();
+  const aliases = new Set<string>();
+  aliases.add(base);
+  if (name) {
+    aliases.add(name);
+    aliases.add(name.replace(/[^a-zA-Z0-9]+/g, " "));
+  }
+  const staticAliases = STATIC_ALIAS_SEEDS[base];
+  if (staticAliases) {
+    for (const alias of staticAliases) aliases.add(alias);
+  }
+  if (/^[a-z]+$/i.test(base) && base.length <= 4) {
+    aliases.add(`${base} crypto`);
+  }
+  const normalizedAliases = Array.from(aliases).map((alias) => alias.trim()).filter(Boolean);
+  const searchTerms = normalizedAliases.map((alias) => `"${alias.toLowerCase()}"`).join(" OR ");
+  const query = `(${searchTerms}) AND (crypto OR token OR coin)`;
+  return { query, aliases: normalizedAliases };
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`Request failed (${res.status}) for ${url}`);
+  }
+  return (await res.json()) as T;
+}
+
+export class HighPotentialScanner {
+  private exchangeCache: { data: BinanceExchangeSymbol[]; expiresAt: number } | null = null;
+  private tickerCache: { data: BinanceTicker24h[]; fetchedAt: number } | null = null;
+  private bookTickerCache: Map<string, { data: BinanceBookTicker; fetchedAt: number }> = new Map();
+  private marketCache: { data: CoinGeckoMarketItem[]; expiresAt: number } | null = null;
+  private socialCache: Map<string, SocialCacheEntry> = new Map();
+  private scanCache: Map<string, ScanCacheEntry> = new Map();
+  private throttling = Promise.resolve();
+
+  formatFiltersFromRequest(req: Request): HighPotentialFilters {
+    const { timeframe, minVolUSD, capMin, capMax, excludeLeveraged } = req.query;
+    const capRange: [number, number] | undefined =
+      capMin !== undefined || capMax !== undefined
+        ? [toNumber(capMin, DEFAULT_FILTERS.capRange[0]), toNumber(capMax, DEFAULT_FILTERS.capRange[1])]
+        : undefined;
+    return normalizeHighPotentialFilters({
+      timeframe: (timeframe as HighPotentialTimeframe | undefined) ?? undefined,
+      minVolUSD: minVolUSD !== undefined ? toNumber(minVolUSD, DEFAULT_FILTERS.minVolUSD) : undefined,
+      excludeLeveraged: excludeLeveraged !== undefined ? excludeLeveraged !== "false" : undefined,
+      capRange,
+    });
+  }
+
+  async getScan(filters: HighPotentialFilters): Promise<HighPotentialResponse> {
+    const key = coinKey(filters);
+    const now = Date.now();
+    const cached = this.scanCache.get(key);
+    if (cached && cached.expiresAt > now) {
+      return cached.data;
+    }
+
+    try {
+      const data = await this.performScan(filters);
+      this.scanCache.set(key, { filtersKey: key, data, expiresAt: now + TEN_MINUTES });
+      return data;
+    } catch (error) {
+      if (cached) {
+        cached.data.dataStale = true;
+        return cached.data;
+      }
+      throw error;
+    }
+  }
+
+  private async performScan(filters: HighPotentialFilters): Promise<HighPotentialResponse> {
+    const exchangeSymbols = await this.getExchangeSymbols();
+    const tickers = await this.getTicker24h();
+
+    const eligible = exchangeSymbols.filter((symbol) => {
+      if (symbol.quoteAsset !== "USDT") return false;
+      if (symbol.status !== "TRADING") return false;
+      const base = symbol.baseAsset.toUpperCase();
+      if (STABLE_BASE_ASSETS.has(base)) return false;
+      if (filters.excludeLeveraged) {
+        for (const keyword of LEVERAGED_KEYWORDS) {
+          if (base.endsWith(keyword) || base.includes(keyword)) return false;
+        }
+      }
+      return true;
+    });
+
+    const tickerMap = new Map(tickers.map((t) => [t.symbol, t] as const));
+
+    const filtered = eligible
+      .map((symbol) => {
+        const ticker = tickerMap.get(symbol.symbol);
+        if (!ticker) return null;
+        const vol = toNumber(ticker.quoteVolume);
+        if (vol < filters.minVolUSD) return null;
+        return { symbol, ticker, volume: vol };
+      })
+      .filter((entry): entry is { symbol: BinanceExchangeSymbol; ticker: BinanceTicker24h; volume: number } =>
+        Boolean(entry),
+      )
+      .sort((a, b) => b.volume - a.volume)
+      .slice(0, 60);
+
+    const marketMap = await this.getMarketMap();
+
+    const timeframe = filters.timeframe;
+    const binanceInterval = TIMEFRAME_TO_BINANCE[timeframe];
+
+    const coins: HighPotentialCoin[] = [];
+    let dataStale = false;
+
+    for (const entry of filtered) {
+      try {
+        const analysed = await this.analyseCoin(entry.symbol, entry.ticker, marketMap, binanceInterval, timeframe);
+        if (!analysed) continue;
+        if (analysed.marketCap < filters.capRange[0] || analysed.marketCap > filters.capRange[1]) continue;
+        coins.push(analysed.coin);
+        if (analysed.socialStale) {
+          dataStale = true;
+        }
+      } catch (error) {
+        console.error("Failed to analyse", entry.symbol.symbol, error);
+        dataStale = true;
+      }
+      await delay(120);
+    }
+
+    coins.sort((a, b) => b.score - a.score);
+    const top = coins.slice(0, 10);
+
+    const buckets = {
+      breakoutZone: coins.filter((coin) => coin.bucket === "Breakout Zone"),
+      oversoldRecovery: coins.filter((coin) => coin.bucket === "Oversold Recovery"),
+      strongMomentum: coins.filter((coin) => coin.bucket === "Strong Momentum"),
+    };
+
+    return {
+      dataStale,
+      timeframe,
+      filters,
+      top,
+      buckets,
+    };
+  }
+  private async analyseCoin(
+    symbol: BinanceExchangeSymbol,
+    ticker: BinanceTicker24h,
+    marketMap: Map<string, CoinGeckoMarketItem>,
+    interval: string,
+    timeframe: HighPotentialTimeframe,
+  ): Promise<{ coin: HighPotentialCoin; context: CoinComputationContext; marketCap: number; socialStale: boolean } | null> {
+    const base = symbol.baseAsset.toUpperCase();
+    const market = marketMap.get(base.toLowerCase()) ?? marketMap.get(base.toUpperCase());
+    if (!market) return null;
+
+    const price = toNumber(ticker.lastPrice);
+    const change24hPct = toNumber(ticker.priceChangePercent);
+    const vol24h = toNumber(ticker.quoteVolume);
+
+    const klines = await binanceService.getKlineData(symbol.symbol, interval, TIMEFRAME_KLINE_LIMIT);
+    if (klines.length < RESISTANCE_LOOKBACK + 5) return null;
+
+    const closes = klines.map((k) => toNumber(k.close));
+    const highs = klines.map((k) => toNumber(k.high));
+    const lows = klines.map((k) => toNumber(k.low));
+    const volumes = klines.map((k) => toNumber(k.volume));
+
+    const rsiSeries = rsi(closes);
+    const rsiValue = rsiSeries.at(-1);
+    if (rsiValue === undefined || Number.isNaN(rsiValue)) return null;
+    const rsiRising =
+      rsiSeries.length >= 4 ? rsiSeries[rsiSeries.length - 1] > rsiSeries[rsiSeries.length - 4] : false;
+
+    const macdData = macd(closes);
+    const macdHistogram = macdData.histogram.at(-1) ?? 0;
+    let macdCrossBullishRecent = false;
+    const macdLen = Math.min(macdData.macd.length, macdData.signal.length);
+    for (let i = Math.max(1, macdLen - 5); i < macdLen; i++) {
+      const prevDiff = macdData.macd[i - 1] - macdData.signal[i - 1];
+      const currDiff = macdData.macd[i] - macdData.signal[i];
+      if (prevDiff <= 0 && currDiff > 0) {
+        macdCrossBullishRecent = true;
+        break;
+      }
+    }
+
+    const adxData = adx(highs, lows, closes);
+    const adxValue = adxData.adx.at(-1) ?? 0;
+    const plusDI = adxData.plusDI.at(-1) ?? 0;
+    const minusDI = adxData.minusDI.at(-1) ?? 0;
+
+    const ema20Series = ema(closes, EMA_FAST);
+    const ema50Series = ema(closes, EMA_MED);
+    const ema200Series = ema(closes, EMA_SLOW);
+    const ema20 = ema20Series.at(-1) ?? 0;
+    const ema50 = ema50Series.at(-1) ?? 0;
+    const ema200 = ema200Series.at(-1) ?? 0;
+    let emaCrossRecent = false;
+    for (let i = Math.max(1, closes.length - 10); i < closes.length; i++) {
+      const prevDiff = ema20Series[i - 1] - ema50Series[i - 1];
+      const currDiff = ema20Series[i] - ema50Series[i];
+      if (prevDiff <= 0 && currDiff > 0) {
+        emaCrossRecent = true;
+        break;
+      }
+    }
+
+    const resistance20 = highest(closes, RESISTANCE_LOOKBACK);
+    const breakoutDistancePct = resistance20 > 0 ? ((resistance20 - price) / resistance20) * 100 : 0;
+
+    const lastVolume = volumes.at(-1) ?? 0;
+    const averageVolume = average(volumes.slice(-INTRA_VOLUME_LOOKBACK));
+    const intraTFVolRatio = averageVolume > 0 ? lastVolume / averageVolume : 0;
+
+    const daily = await binanceService.getKlineData(symbol.symbol, "1d", 30);
+    const last7 = daily.slice(-7);
+    const vol7dArr = last7.map((k) => toNumber(k.volume) * toNumber(k.close));
+    const vol7dAvg = average(vol7dArr);
+    const sparkline = last7.map((k) => toNumber(k.close));
+    const volumeRatio = vol7dAvg > 0 ? vol24h / vol7dAvg : 0;
+
+    const bookTicker = await this.getBookTicker(symbol.symbol);
+    const spreadPct = calcSpreadPct(bookTicker);
+
+    const socialResult = await this.getSocialData(symbol.baseAsset, market.name, timeframe);
+
+    const context: CoinComputationContext = {
+      rsiValue,
+      rsiRising,
+      volumeRatio,
+      intraVolumeRatio: intraTFVolRatio,
+      macdHistogram,
+      macdCrossBullishRecent,
+      adxValue,
+      plusDI,
+      minusDI,
+      ema20,
+      ema50,
+      ema200,
+      emaCrossRecent,
+      price,
+      distancePct: breakoutDistancePct,
+      vol24h,
+      spreadPct,
+      marketCap: market.market_cap ?? 0,
+      social: socialResult.data,
+      headlineDelta: socialResult.data.pos - socialResult.data.neg,
+    };
+
+    const momentum = scoreMomentum(context);
+    const volume = scoreVolume(context);
+    const breakout = scoreBreakout(context);
+    const marketCapScore = scoreMarketCap(context.marketCap);
+    const socialScore = scoreSocial(context);
+    const quality = scoreQuality(context);
+
+    let totalScore = momentum + volume + breakout + marketCapScore + socialScore + quality;
+    if (!Number.isFinite(totalScore)) totalScore = 0;
+    totalScore = Math.max(0, Math.min(100, totalScore));
+
+    const coin: HighPotentialCoin = {
+      symbol: symbol.symbol,
+      baseAsset: symbol.baseAsset,
+      name: market.name || symbol.baseAsset,
+      price,
+      change24hPct,
+      vol24h,
+      vol7dAvg,
+      intraTFVolRatio: intraTFVolRatio,
+      rsi: rsiValue,
+      macd: { crossBullishRecent: macdCrossBullishRecent, histogram: macdHistogram },
+      adx: { adx: adxValue, plusDI, minusDI },
+      ema: { ema20, ema50, ema200 },
+      resistance20,
+      breakoutDistancePct,
+      marketCap: context.marketCap,
+      marketCapRank: market.market_cap_rank ?? null,
+      social: socialResult.data,
+      score: Math.round(totalScore),
+      confidence: computeConfidence(totalScore),
+      bucket: null,
+      sparkline,
+      updatedAt: Math.floor(Date.now() / 1000),
+    };
+
+    coin.bucket = assignBucket(context);
+
+    return { coin, context, marketCap: context.marketCap, socialStale: socialResult.stale };
+  }
+
+  private async getExchangeSymbols(): Promise<BinanceExchangeSymbol[]> {
+    const now = Date.now();
+    if (this.exchangeCache && this.exchangeCache.expiresAt > now) {
+      return this.exchangeCache.data;
+    }
+    const info = await binanceService.getExchangeInfo();
+    const symbols: BinanceExchangeSymbol[] = Array.isArray(info.symbols)
+      ? info.symbols.map((s: any) => ({
+          symbol: String(s.symbol),
+          baseAsset: String(s.baseAsset),
+          quoteAsset: String(s.quoteAsset),
+          status: String(s.status),
+        }))
+      : [];
+    this.exchangeCache = { data: symbols, expiresAt: now + EXCHANGE_CACHE_MS };
+    return symbols;
+  }
+
+  private async getTicker24h(): Promise<BinanceTicker24h[]> {
+    const now = Date.now();
+    if (this.tickerCache && now - this.tickerCache.fetchedAt < 60_000) {
+      return this.tickerCache.data;
+    }
+    const data = await fetchJson<BinanceTicker24h[]>("https://api.binance.com/api/v3/ticker/24hr");
+    this.tickerCache = { data, fetchedAt: now };
+    return data;
+  }
+
+  private async getBookTicker(symbol: string): Promise<BinanceBookTicker | null> {
+    const cached = this.bookTickerCache.get(symbol);
+    const now = Date.now();
+    if (cached && now - cached.fetchedAt < 30_000) {
+      return cached.data;
+    }
+    try {
+      const data = await fetchJson<BinanceBookTicker>(
+        `https://api.binance.com/api/v3/ticker/bookTicker?symbol=${encodeURIComponent(symbol)}`,
+      );
+      this.bookTickerCache.set(symbol, { data, fetchedAt: now });
+      return data;
+    } catch (error) {
+      console.warn("Failed to fetch book ticker", symbol, error);
+      return null;
+    }
+  }
+
+  private async getMarketList(): Promise<CoinGeckoMarketItem[]> {
+    const now = Date.now();
+    if (this.marketCache && this.marketCache.expiresAt > now) {
+      return this.marketCache.data;
+    }
+    const results: CoinGeckoMarketItem[] = [];
+    for (let page = 1; page <= COINGECKO_PAGES; page++) {
+      const url =
+        `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=250&page=${page}&price_change_percentage=24h`;
+      const pageData = await fetchJson<CoinGeckoMarketItem[]>(url);
+      results.push(
+        ...pageData.map((item) => ({
+          id: item.id,
+          symbol: item.symbol,
+          name: item.name,
+          market_cap: item.market_cap,
+          market_cap_rank: item.market_cap_rank ?? null,
+        })),
+      );
+      await delay(250);
+    }
+    this.marketCache = { data: results, expiresAt: now + MARKET_CACHE_MS };
+    return results;
+  }
+
+  private async getMarketMap(): Promise<Map<string, CoinGeckoMarketItem>> {
+    const list = await this.getMarketList();
+    const map = new Map<string, CoinGeckoMarketItem>();
+    for (const item of list) {
+      const symbol = (item.symbol || "").toUpperCase();
+      if (!symbol) continue;
+      const existing = map.get(symbol);
+      if (!existing || (existing.market_cap ?? 0) < (item.market_cap ?? 0)) {
+        map.set(symbol, item);
+      }
+    }
+    return map;
+  }
+
+  private async getSocialData(
+    symbol: string,
+    name: string,
+    timeframe: HighPotentialTimeframe,
+  ): Promise<{ data: HighPotentialSocial; stale: boolean }> {
+    const key = `${symbol.toUpperCase()}-${timeframe}`;
+    const now = Date.now();
+    const cached = this.socialCache.get(key);
+    if (cached && cached.expiresAt > now) {
+      return { data: cached.data, stale: false };
+    }
+
+    const token = process.env.CRYPTOPANIC_TOKEN || process.env.CRYPTOPANIC_KEY;
+    if (!token) {
+      return { data: { pos: 0, neg: 0, neu: 0, avgVoteDelta: 0 }, stale: true };
+    }
+
+    try {
+      await this.throttleCryptoPanic();
+      const bundle = buildAliasBundle(symbol, name);
+      const params = new URLSearchParams();
+      params.set("auth_token", token);
+      params.set("public", "true");
+      params.set("kind", "news");
+      params.set("filter", "all");
+      params.set("q", bundle.query);
+      const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      params.set("since", since);
+      const url = `${CRYPTOPANIC_ENDPOINT}?${params.toString()}`;
+      const payload = await fetchJson<{ results?: any[] }>(url);
+      const posts = Array.isArray(payload.results) ? payload.results : [];
+
+      const keepSince = Date.now() - 24 * 60 * 60 * 1000;
+      const seen = new Set<string>();
+      let pos = 0;
+      let neg = 0;
+      let neu = 0;
+      let voteDeltaSum = 0;
+      let voteDeltaCount = 0;
+
+      for (const post of posts) {
+        const publishedAt = new Date(post.published_at ?? post.date ?? 0).getTime();
+        if (Number.isFinite(publishedAt) && publishedAt < keepSince) continue;
+        const title = String(post.title ?? "");
+        const description = String(post.description ?? post.summary ?? "");
+        const combined = `${title} ${description}`.toLowerCase();
+        if (!bundle.aliases.some((alias) => combined.includes(alias.toLowerCase()))) continue;
+        if (CRYPTOPANIC_SPAM_PATTERNS.some((pattern) => pattern.test(combined))) continue;
+        const normalizedTitle = title.toLowerCase().replace(/[^a-z0-9]+/g, "");
+        const normalizedUrl = String(post.url ?? post.source?.url ?? normalizedTitle);
+        const dedupeKey = normalizedUrl || normalizedTitle;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+
+        const sentiment = String(post.sentiment || post.metadata?.sentiment || "neutral").toLowerCase();
+        const votes = post.votes ?? {};
+        const up = toNumber(votes.up ?? votes.positive ?? votes.like ?? votes.vote_up ?? 0);
+        const down = toNumber(votes.down ?? votes.negative ?? votes.dislike ?? votes.vote_down ?? 0);
+        const voteDelta = up - down;
+
+        if (sentiment === "positive") {
+          pos++;
+          voteDeltaSum += voteDelta;
+          voteDeltaCount++;
+        } else if (sentiment === "negative") {
+          neg++;
+        } else {
+          neu++;
+        }
+      }
+
+      const data: HighPotentialSocial = {
+        pos,
+        neg,
+        neu,
+        avgVoteDelta: voteDeltaCount > 0 ? voteDeltaSum / voteDeltaCount : 0,
+      };
+
+      this.socialCache.set(key, { data, expiresAt: now + TEN_MINUTES, updatedAt: now });
+      return { data, stale: false };
+    } catch (error) {
+      console.warn("CryptoPanic request failed", symbol, error);
+      return { data: { pos: 0, neg: 0, neu: 0, avgVoteDelta: 0 }, stale: true };
+    }
+  }
+
+  private throttleCryptoPanic(): Promise<void> {
+    this.throttling = this.throttling.then(() => delay(2000));
+    return this.throttling;
+  }
+}
+
+export const highPotentialScanner = new HighPotentialScanner();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,6 +5,7 @@ import { binanceService } from "./services/binanceService";
 import { technicalIndicators } from "./services/technicalIndicators";
 import { aiService } from "./services/aiService";
 import { portfolioService } from "./services/portfolioService";
+import { highPotentialScanner } from "./highPotential/scanner";
 import { insertPortfolioPositionSchema, insertWatchlistItemSchema, insertTradeTransactionSchema } from "@shared/schema";
 import { z } from "zod";
 
@@ -340,25 +341,14 @@ export function registerRoutes(app: Express): void {
     }
   });
 
-  app.post('/api/scanner/high-potential', isAuthenticated, async (req: Request, res: Response) => {
+  app.get('/api/high-potential', async (req: Request, res: Response) => {
     try {
-      const userId = (req as any).user.id;
-      const filters = req.body;
-
-      const results = await technicalIndicators.scanHighPotential(filters);
-      
-      // Save scan history
-      await storage.createScanHistory({
-        userId,
-        scanType: 'high_potential',
-        filters,
-        results,
-      });
-      
-      res.json(results);
+      const filters = highPotentialScanner.formatFiltersFromRequest(req);
+      const data = await highPotentialScanner.getScan(filters);
+      res.json(data);
     } catch (error) {
-      console.error("Error scanning high potential:", error);
-      res.status(500).json({ message: "Failed to scan high potential coins" });
+      console.error("Error generating high potential scan:", error);
+      res.status(500).json({ message: "Failed to load high potential data" });
     }
   });
 

--- a/shared/high-potential/types.ts
+++ b/shared/high-potential/types.ts
@@ -1,0 +1,66 @@
+export type HighPotentialTimeframe = "1h" | "4h" | "1d";
+
+export interface HighPotentialFilters {
+  timeframe: HighPotentialTimeframe;
+  minVolUSD: number;
+  excludeLeveraged: boolean;
+  capRange: [number, number];
+}
+
+export interface HighPotentialSocial {
+  pos: number;
+  neg: number;
+  neu: number;
+  avgVoteDelta: number;
+}
+
+export interface HighPotentialCoin {
+  symbol: string;
+  baseAsset: string;
+  name: string;
+  price: number;
+  change24hPct: number;
+  vol24h: number;
+  vol7dAvg: number;
+  intraTFVolRatio: number;
+  rsi: number;
+  macd: {
+    crossBullishRecent: boolean;
+    histogram: number;
+  };
+  adx: {
+    adx: number;
+    plusDI: number;
+    minusDI: number;
+  };
+  ema: {
+    ema20: number;
+    ema50: number;
+    ema200: number;
+  };
+  resistance20: number;
+  breakoutDistancePct: number;
+  marketCap: number;
+  marketCapRank?: number | null;
+  social: HighPotentialSocial;
+  score: number;
+  confidence: "High" | "Medium" | "Watch" | "Low";
+  bucket: "Breakout Zone" | "Oversold Recovery" | "Strong Momentum" | null;
+  sparkline: number[];
+  updatedAt: number;
+  dataStale?: boolean;
+}
+
+export interface HighPotentialBuckets {
+  breakoutZone: HighPotentialCoin[];
+  oversoldRecovery: HighPotentialCoin[];
+  strongMomentum: HighPotentialCoin[];
+}
+
+export interface HighPotentialResponse {
+  dataStale: boolean;
+  timeframe: HighPotentialTimeframe;
+  filters: HighPotentialFilters;
+  top: HighPotentialCoin[];
+  buckets: HighPotentialBuckets;
+}


### PR DESCRIPTION
## Summary
- add shared high potential types and a new backend scanner that aggregates Binance, CoinGecko, and CryptoPanic data with scoring, caching, and bucket classification
- rebuild the High Potential page with scoped filters, auto-refresh, top-ten cards, and bucket tabs backed by the new API
- update API handlers, server routes, and dependent pages to consume the new response format for counts and recommendations

## Testing
- `npm run check` *(fails: missing type definitions for `node` and `vite/client` in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e287346d948323a3a7e1c9a6cca372