### PR TITLE
Switch high potential scanner to tf query param

### DIFF
--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -412,7 +412,7 @@ export default function Analyse() {
     staleTime: 10 * 60_000,
     queryFn: async () => {
       const params = new URLSearchParams({
-        timeframe: timeframeConfig?.backend || "4h",
+        tf: timeframeConfig?.backend || "4h",
         minVolUSD: "2000000",
         capMin: "0",
         capMax: "2000000000",

--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -341,7 +341,7 @@ export default function Charts() {
     staleTime: 10 * 60_000,
     queryFn: async () => {
       const params = new URLSearchParams({
-        timeframe: timeframeConfig?.backend || "4h",
+        tf: timeframeConfig?.backend || "4h",
         minVolUSD: "2000000",
         capMin: "0",
         capMax: "2000000000",

--- a/client/src/pages/high-potential.tsx
+++ b/client/src/pages/high-potential.tsx
@@ -138,7 +138,7 @@ function formatNumber(value: number): string {
 
 async function fetchHighPotential(filters: FilterState): Promise<HighPotentialResponse> {
   const params = new URLSearchParams();
-  params.set("timeframe", filters.timeframe);
+  params.set("tf", filters.timeframe);
   params.set("minVolUSD", Math.round(filters.minVolUSD).toString());
   params.set("excludeLeveraged", String(filters.excludeLeveraged));
   params.set("capMin", Math.round(filters.capRange[0]).toString());

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -86,7 +86,7 @@ async function qPortfolioSummary(): Promise<{ totalValue: number | null; totalPn
 
 async function qHighPotentialCount(): Promise<{ count: number | null; ts: number }> {
   const params = new URLSearchParams({
-    timeframe: "4h",
+    tf: "4h",
     minVolUSD: "2000000",
     capMin: "0",
     capMax: "2000000000",

--- a/server/highPotential/scanner.test.ts
+++ b/server/highPotential/scanner.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Request } from "express";
+import { highPotentialScanner, InvalidHighPotentialFiltersError } from "./scanner";
+
+test("formatFiltersFromRequest uses the tf query parameter when present", () => {
+  const req = { query: { tf: "4h" } } as unknown as Request;
+  const filters = highPotentialScanner.formatFiltersFromRequest(req);
+  assert.equal(filters.timeframe, "4h");
+});
+
+test("formatFiltersFromRequest rejects the legacy timeframe query parameter", () => {
+  const req = { query: { timeframe: "4h" } } as unknown as Request;
+  assert.throws(
+    () => highPotentialScanner.formatFiltersFromRequest(req),
+    InvalidHighPotentialFiltersError,
+  );
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -5,7 +5,7 @@ import { binanceService } from "./services/binanceService";
 import { technicalIndicators } from "./services/technicalIndicators";
 import { aiService } from "./services/aiService";
 import { portfolioService } from "./services/portfolioService";
-import { highPotentialScanner } from "./highPotential/scanner";
+import { highPotentialScanner, InvalidHighPotentialFiltersError } from "./highPotential/scanner";
 import { insertPortfolioPositionSchema, insertWatchlistItemSchema, insertTradeTransactionSchema } from "@shared/schema";
 import { z } from "zod";
 
@@ -347,6 +347,11 @@ export function registerRoutes(app: Express): void {
       const data = await highPotentialScanner.getScan(filters);
       res.json(data);
     } catch (error) {
+      if (error instanceof InvalidHighPotentialFiltersError) {
+        console.warn("Rejected high potential scan request", error);
+        res.status(400).json({ message: error.message });
+        return;
+      }
       console.error("Error generating high potential scan:", error);
       res.status(500).json({ message: "Failed to load high potential data" });
     }

--- a/server/services/binanceService.ts
+++ b/server/services/binanceService.ts
@@ -1,0 +1,1 @@
+export { binanceService } from "../../api/services/binanceService";


### PR DESCRIPTION
## Summary
- enforce the new `tf` query parameter in the high potential scanner and reject legacy `timeframe` usage
- update the Vercel handler and client fetchers to send `tf`, `minVolUSD`, `capMin`, `capMax`, and `excludeLeveraged`
- add regression coverage ensuring the new parameter is parsed while the legacy key fails

## Testing
- npx --yes tsx --test server/highPotential/scanner.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e28f6137e48323908b48f1b2874754