### PR TITLE
Handle cached fallback when the high potential scanner is offline

### DIFF
--- a/client/src/pages/high-potential-cache.test.ts
+++ b/client/src/pages/high-potential-cache.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { HighPotentialResponse } from "@shared/high-potential/types";
+import {
+  deriveScannerState,
+  loadCachedResponse,
+  storeCachedResponse,
+  type CachedHighPotentialEntry,
+  type HighPotentialFiltersSnapshot,
+  type StorageLike,
+} from "./high-potential-cache";
+
+class MemoryStorage implements StorageLike {
+  #map = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.#map.has(key) ? this.#map.get(key)! : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.#map.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.#map.delete(key);
+  }
+}
+
+const filters: HighPotentialFiltersSnapshot = {
+  timeframe: "1h",
+  minVolUSD: 1_000_000,
+  capMin: 0,
+  capMax: 5_000_000_000,
+  excludeLeveraged: true,
+};
+
+function createResponse(overrides: Partial<HighPotentialResponse> = {}): HighPotentialResponse {
+  return {
+    dataStale: false,
+    timeframe: "1h",
+    filters: {
+      timeframe: "1h",
+      minVolUSD: 1_000_000,
+      excludeLeveraged: true,
+      capRange: [0, 5_000_000_000],
+    },
+    top: [],
+    buckets: {
+      breakoutZone: [],
+      oversoldRecovery: [],
+      strongMomentum: [],
+    },
+    ...overrides,
+  };
+}
+
+test("storeCachedResponse persists payload metadata", () => {
+  const storage = new MemoryStorage();
+  const payload = createResponse({ dataStale: true });
+  const timestamp = 1_700_000_000_000;
+
+  const entry = storeCachedResponse(storage, filters, payload, timestamp);
+  assert.equal(entry.timestamp, timestamp);
+  assert.equal(entry.dataStale, true);
+  assert.deepEqual(entry.payload, payload);
+
+  const loaded = loadCachedResponse(storage, filters);
+  assert.deepEqual(loaded, entry);
+});
+
+test("deriveScannerState uses cached payload when query errors", () => {
+  const cachedPayload = createResponse({
+    top: [{
+      symbol: "BTCUSDT",
+      baseAsset: "BTC",
+      name: "Bitcoin",
+      price: 50000,
+      change24hPct: 2,
+      vol24h: 1000000000,
+      vol7dAvg: 800000000,
+      intraTFVolRatio: 1.2,
+      rsi: 55,
+      macd: { crossBullishRecent: true, histogram: 1.5 },
+      adx: { adx: 25, plusDI: 30, minusDI: 15 },
+      ema: { ema20: 48000, ema50: 47000, ema200: 45000 },
+      resistance20: 51000,
+      breakoutDistancePct: 2.1,
+      marketCap: 900_000_000_000,
+      marketCapRank: 1,
+      social: { pos: 60, neg: 10, neu: 30, avgVoteDelta: 0.5 },
+      score: 24,
+      confidence: "High",
+      bucket: "Breakout Zone",
+      sparkline: [48000, 48500, 49000, 50000],
+      updatedAt: 1_700_000_000,
+      dataStale: false,
+    }],
+    buckets: {
+      breakoutZone: [],
+      oversoldRecovery: [],
+      strongMomentum: [],
+    },
+  });
+  const cachedEntry: CachedHighPotentialEntry = {
+    timestamp: Date.now(),
+    dataStale: false,
+    payload: cachedPayload,
+  };
+
+  const state = deriveScannerState({ queryData: null, queryError: new Error("boom"), cachedEntry });
+  assert.equal(state.resolvedData, cachedPayload);
+  assert.equal(state.usingCache, true);
+  assert.equal(state.showOfflineBanner, true);
+  assert.equal(state.showUnavailableState, false);
+});
+
+test("deriveScannerState surfaces unavailable state when cache is empty", () => {
+  const state = deriveScannerState({ queryData: null, queryError: new Error("network"), cachedEntry: null });
+  assert.equal(state.resolvedData, null);
+  assert.equal(state.usingCache, false);
+  assert.equal(state.showOfflineBanner, false);
+  assert.equal(state.showUnavailableState, true);
+});

--- a/client/src/pages/high-potential-cache.ts
+++ b/client/src/pages/high-potential-cache.ts
@@ -1,0 +1,107 @@
+import type { HighPotentialResponse, HighPotentialTimeframe } from "@shared/high-potential/types";
+
+export type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+};
+
+export type HighPotentialFiltersSnapshot = {
+  timeframe: HighPotentialTimeframe;
+  minVolUSD: number;
+  capMin: number;
+  capMax: number;
+  excludeLeveraged: boolean;
+};
+
+export type CachedHighPotentialEntry = {
+  timestamp: number;
+  dataStale: boolean;
+  payload: HighPotentialResponse;
+};
+
+const CACHE_PREFIX = "high-potential:last-success";
+
+export function createCacheKey(filters: HighPotentialFiltersSnapshot): string {
+  return [
+    CACHE_PREFIX,
+    filters.timeframe,
+    Math.round(filters.minVolUSD),
+    Math.round(filters.capMin),
+    Math.round(filters.capMax),
+    filters.excludeLeveraged ? "1" : "0",
+  ].join(":");
+}
+
+export function storeCachedResponse(
+  storage: StorageLike,
+  filters: HighPotentialFiltersSnapshot,
+  payload: HighPotentialResponse,
+  timestamp: number = Date.now(),
+): CachedHighPotentialEntry {
+  const entry: CachedHighPotentialEntry = {
+    timestamp,
+    dataStale: Boolean(payload.dataStale),
+    payload,
+  };
+  storage.setItem(createCacheKey(filters), JSON.stringify(entry));
+  return entry;
+}
+
+export function loadCachedResponse(
+  storage: StorageLike | null | undefined,
+  filters: HighPotentialFiltersSnapshot,
+): CachedHighPotentialEntry | null {
+  if (!storage) return null;
+  const raw = storage.getItem(createCacheKey(filters));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CachedHighPotentialEntry>;
+    if (!parsed || typeof parsed !== "object" || !parsed.payload) {
+      return null;
+    }
+    const timestamp = typeof parsed.timestamp === "number" ? parsed.timestamp : Date.now();
+    const dataStale = Boolean(parsed.dataStale);
+    return {
+      timestamp,
+      dataStale,
+      payload: parsed.payload as HighPotentialResponse,
+    };
+  } catch (error) {
+    console.warn("Failed to parse cached high potential response", error);
+    storage.removeItem?.(createCacheKey(filters));
+    return null;
+  }
+}
+
+export type ScannerStateInput = {
+  queryData: HighPotentialResponse | null | undefined;
+  queryError: unknown;
+  cachedEntry: CachedHighPotentialEntry | null | undefined;
+};
+
+export type ScannerState = {
+  resolvedData: HighPotentialResponse | null;
+  usingCache: boolean;
+  showOfflineBanner: boolean;
+  showUnavailableState: boolean;
+};
+
+export function deriveScannerState({
+  queryData,
+  queryError,
+  cachedEntry,
+}: ScannerStateInput): ScannerState {
+  const hasError = Boolean(queryError);
+  const cachedPayload = cachedEntry?.payload ?? null;
+  const resolvedData = queryData ?? cachedPayload ?? null;
+  const usingCache = Boolean(hasError && !queryData && cachedPayload);
+  const showOfflineBanner = Boolean(hasError && cachedPayload);
+  const showUnavailableState = Boolean(hasError && !resolvedData);
+  return {
+    resolvedData,
+    usingCache,
+    showOfflineBanner,
+    showUnavailableState,
+  };
+}


### PR DESCRIPTION
## Summary
- cache the latest successful high potential scan payload in sessionStorage alongside metadata
- surface scanner fetch errors with a fallback banner and error messaging that reuses the cached payload when available
- extract reusable caching utilities and cover cached and uncached error flows with node:test coverage

## Testing
- node --test --import tsx client/src/pages/high-potential-cache.test.ts
- node --test --import tsx server/highPotential/scanner.test.ts
- npm run check *(fails: repository contains pre-existing type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e2944b9e5083238a7b74925145a46b