### PR TITLE
Fix CORS configuration for API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
+        "cors": "^2.8.5",
         "date-fns": "^3.6.0",
         "dotenv": "^17.2.2",
         "drizzle-orm": "^0.39.1",
@@ -5481,6 +5482,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
+    "cors": "^2.8.5",
     "date-fns": "^3.6.0",
     "dotenv": "^17.2.2",
     "drizzle-orm": "^0.39.1",


### PR DESCRIPTION
## Summary
- add the cors dependency and configure the Express app to allow the dashboard origin, local dev hosts, and vercel previews while always setting the proper headers and handling preflight/error responses
- ensure `/api/health` continues to return the documented payload and update the high potential scan logging format

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ac0234848323b258de3f932147c4