### PR TITLE
chore: centralize scan result typing

### DIFF
--- a/client/src/components/scanner/technical-indicators.tsx
+++ b/client/src/components/scanner/technical-indicators.tsx
@@ -1,5 +1,10 @@
 // client/src/components/scanner/technical-indicators.tsx
 import * as React from "react";
+import type {
+  ScanIndicator,
+  ScanResult,
+  ScanSignal,
+} from "@shared/types/scanner";
 
 /**
  * Renders ALL indicators returned by the scan API instead of relying on a hardcoded list.
@@ -8,24 +13,13 @@ import * as React from "react";
  * - Robust to null/undefined fields so it never crashes the page.
  */
 
-type Signal = "bullish" | "bearish" | "neutral";
-
-type Indicator = {
-  value: number | null | undefined;
-  signal?: Signal | string | null;
-  score?: number | null;
-  tier?: number | null;
-  description?: string | null;
-  // Future-friendly: API can add fields; we ignore them safely.
-};
-
-type ScanResult = {
-  symbol: string;
-  price: number;
-  indicators: Record<string, Indicator> | null | undefined;
-  totalScore: number;
-  recommendation: "strong_buy" | "buy" | "hold" | "sell" | "strong_sell";
-  meta?: Record<string, any>;
+type NormalizedIndicator = {
+  value: number | null;
+  signal: ScanSignal;
+  score: number;
+  tier: number;
+  description: string;
+  key?: string;
 };
 
 export default function TechnicalIndicators({
@@ -81,14 +75,7 @@ function IndicatorCard({
   indicator,
 }: {
   id: string;
-  indicator: {
-    value: number | null;
-    signal: Signal;
-    score: number;
-    tier: number;
-    description: string;
-    key?: string;
-  };
+  indicator: NormalizedIndicator;
 }) {
   const { value, signal, score, tier, description } = indicator;
 
@@ -158,7 +145,7 @@ function isFiniteNumber(n: unknown): n is number {
   return typeof n === "number" && Number.isFinite(n);
 }
 
-function normalizeSignal(sig: unknown): Signal {
+function normalizeSignal(sig: ScanIndicator["signal"]): ScanSignal {
   const s = String(sig ?? "").toLowerCase();
   if (s === "bullish" || s === "bearish" || s === "neutral") return s;
   return "neutral";

--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -27,6 +27,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { toBinance } from "@/lib/symbols";
 import { useRoute, useLocation } from "wouter";
 import type { HighPotentialResponse } from "@shared/high-potential/types";
+import type { ScanResult } from "@shared/types/scanner";
 import {
   Activity,
   BarChart3,
@@ -54,23 +55,6 @@ interface PriceData {
   quoteVolume: string;
   highPrice: string;
   lowPrice: string;
-}
-
-interface ScanIndicator {
-  value?: number;
-  signal?: "bullish" | "bearish" | "neutral";
-  score?: number;
-  tier?: number;
-  description?: string;
-}
-
-interface ScanResult {
-  symbol: string;
-  price: number;
-  indicators: Record<string, ScanIndicator>;
-  totalScore: number;
-  recommendation: "strong_buy" | "buy" | "hold" | "sell" | "strong_sell";
-  meta?: Record<string, unknown> | null;
 }
 
 interface WatchlistItem {

--- a/shared/types/scanner.ts
+++ b/shared/types/scanner.ts
@@ -1,0 +1,19 @@
+export type ScanSignal = "bullish" | "bearish" | "neutral";
+
+export interface ScanIndicator {
+  value?: number | null;
+  signal?: ScanSignal | string | null;
+  score?: number | null;
+  tier?: number | null;
+  description?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ScanResult {
+  symbol: string;
+  price: number;
+  indicators?: Record<string, ScanIndicator | null> | null;
+  totalScore: number;
+  recommendation: "strong_buy" | "buy" | "hold" | "sell" | "strong_sell";
+  meta?: Record<string, unknown> | null;
+}


### PR DESCRIPTION
## Summary
- add a shared scanner type definition that reflects the scan API contract
- refactor the technical indicators component and charts page to consume the shared type while keeping nullable indicator fields consistent

## Testing
- npm run check *(fails: existing type errors in unrelated files such as analyse.tsx and high-potential.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e78e3b788323b6ff8e0cd0fe2cbc