### PR TITLE
Update high potential query options for React Query v5

### DIFF
--- a/client/src/pages/high-potential.tsx
+++ b/client/src/pages/high-potential.tsx
@@ -207,18 +207,21 @@ export default function HighPotentialPage() {
     [filters.timeframe, filters.minVolUSD, filters.capRange, filters.excludeLeveraged],
   );
 
-  const query = useQuery({
+  const query = useQuery<HighPotentialResponse>({
     queryKey,
     queryFn: () => fetchHighPotential(filters),
     refetchInterval: filters.autoRefresh ? AUTO_REFRESH_INTERVAL : false,
-    keepPreviousData: true,
-    onSuccess: (response: HighPotentialResponse) => {
-      if (typeof window === "undefined") return;
-      setCachedEntry(storeCachedResponse(window.localStorage, filtersSnapshot, response));
-    },
+    placeholderData: (previousData) => previousData,
+    staleTime: 0,
   });
 
   const { data: queryData, isLoading, isFetching, refetch, error } = query;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!query.data || query.dataUpdatedAt === 0) return;
+    setCachedEntry(storeCachedResponse(window.localStorage, filtersSnapshot, query.data));
+  }, [filtersSnapshot, query.data, query.dataUpdatedAt]);
 
   const { resolvedData, errorBannerMessage, showUnavailableState } = deriveScannerState({
     queryData,


### PR DESCRIPTION
## Summary
- replace the deprecated `keepPreviousData` flag in the high potential scanner with the React Query v5 `placeholderData` pattern and stale settings
- type the scanner query as `UseQueryResult<HighPotentialResponse>` so consumers receive strongly typed data
- trigger cache persistence via an effect when fresh data arrives to preserve the cached scanner behaviour

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e98464488323a99677a8fb4d584d