### PR TITLE
Make asArray generic and tighten query typing

### DIFF
--- a/client/src/lib/disableLocalWs.ts
+++ b/client/src/lib/disableLocalWs.ts
@@ -38,7 +38,6 @@
       /* fall through to real WS */
     }
     // Everything else (like Binance) goes through as normal
-    // @ts-expect-error: delegating to native constructor
     return new NativeWS(url, protocols);
   }
 

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -5,7 +5,19 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const asArray = (x: any) =>
-  Array.isArray(x) ? x : Array.isArray(x?.data) ? x.data : []
+export const asArray = <T>(input: unknown): T[] => {
+  if (Array.isArray(input)) {
+    return input as T[]
+  }
+
+  if (input && typeof input === "object") {
+    const data = (input as { data?: unknown }).data
+    if (Array.isArray(data)) {
+      return data as T[]
+    }
+  }
+
+  return []
+}
 
 export const asString = (v: any) => (v ?? "").toString()

--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -97,7 +97,7 @@ interface ScanHistoryItem {
   id: string;
   scanType: string;
   filters?: { symbol?: string; timeframe?: string } | null;
-  results?: ScanResult | null;
+  results?: ScanResult | ScannerAnalysis | null;
   createdAt?: number | string | null;
 }
 
@@ -189,7 +189,9 @@ export default function Analyse() {
     const base = initialSymbol.endsWith("USDT") ? initialSymbol.slice(0, -4) : initialSymbol;
     return base || "BTC";
   });
-  const [scanResult, setScanResult] = useState<ScannerAnalysis | null>(null);
+  const [scanResult, setScanResult] = useState<ScannerAnalysis | ScanResult | null>(
+    null,
+  );
   const [isScanning, setIsScanning] = useState(false);
   const lastRequestIdRef = useRef<string>("");
   const previousSymbolRef = useRef<string>(initialSymbol);
@@ -389,7 +391,7 @@ export default function Analyse() {
     },
   });
 
-  const watchlistItems = asArray(watchlistQuery);
+  const watchlistItems = asArray<WatchlistItem>(watchlistQuery.data);
   const historyQuery = useQuery({
     queryKey: ["scan-history"],
     enabled: isAuthenticated && networkEnabled,
@@ -399,7 +401,7 @@ export default function Analyse() {
     },
   });
 
-  const historyItems = asArray(historyQuery);
+  const historyItems = asArray<ScanHistoryItem>(historyQuery.data);
 
   const timeframeConfig = useMemo(
     () => TIMEFRAMES.find((tf) => tf.value === selectedTimeframe),
@@ -432,7 +434,7 @@ export default function Analyse() {
     },
   });
 
-  const highPotentialItems = asArray(highPotentialQuery);
+  const highPotentialItems = asArray<ScanResult>(highPotentialQuery.data);
 
   const addToWatchlist = useMutation({
     mutationFn: async (symbol: string) => {

--- a/client/src/pages/charts.original.backup.tsx
+++ b/client/src/pages/charts.original.backup.tsx
@@ -176,7 +176,7 @@ export default function Charts() {
       setScanResult(data);
     },
     onError: (error: unknown) => {
-      if (isUnauthorizedError(error)) {
+      if (error instanceof Error && isUnauthorizedError(error)) {
         toast({
           title: "Unauthorized",
           description: "You are logged out. Logging in again...",

--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -301,7 +301,7 @@ export default function Charts() {
     },
   });
 
-  const watchlistItems = asArray(watchlistQuery);
+  const watchlistItems = asArray<WatchlistItem>(watchlistQuery.data);
 
   const historyQuery = useQuery({
     queryKey: ["scan-history"],
@@ -312,7 +312,7 @@ export default function Charts() {
     },
   });
 
-  const historyItems = asArray(historyQuery);
+  const historyItems = asArray<ScanHistoryItem>(historyQuery.data);
 
   const timeframeConfig = useMemo(
     () => TIMEFRAMES.find((tf) => tf.value === selectedTimeframe),
@@ -345,7 +345,7 @@ export default function Charts() {
     },
   });
 
-  const highPotentialItems = asArray(highPotentialQuery);
+  const highPotentialItems = asArray<ScanResult>(highPotentialQuery.data);
 
   const addToWatchlist = useMutation({
     mutationFn: async (symbol: string) => {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -80,7 +80,7 @@ async function safeJson<T>(path: string, init?: RequestInit): Promise<T | null> 
 async function qPortfolioSummary(): Promise<{ totalValue: number | null; totalPnlPercent: number | null }> {
   const summary = await safeJson<PortfolioSummary>("/api/portfolio");
   const totalValue = toNum(summary?.totalValue ?? null);
-  const totalPnlPercent = toNum(summary?.totalPnLPercent ?? summary?.totalPnlPercent ?? null);
+  const totalPnlPercent = toNum(summary?.totalPnLPercent ?? null);
   return { totalValue: totalValue ?? null, totalPnlPercent: totalPnlPercent ?? null };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@radix-ui/react-tooltip": "^1.2.0",
         "@tanstack/react-query": "^5.60.5",
         "@types/memoizee": "^0.4.12",
+        "@types/uuid": "^10.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -75,6 +76,7 @@
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.2.5",
+        "uuid": "^13.0.0",
         "vaul": "^1.1.2",
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
@@ -4500,6 +4502,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -9626,6 +9634,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tanstack/react-query": "^5.60.5",
     "@types/memoizee": "^0.4.12",
+    "@types/uuid": "^10.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -55,6 +56,7 @@
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
+    "firebase": "^10.12.4",
     "framer-motion": "^11.13.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.453.0",
@@ -71,18 +73,17 @@
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
     "react-resizable-panels": "^2.1.7",
+    "react-router-dom": "^6.26.2",
     "recharts": "^2.15.4",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.2.5",
+    "uuid": "^13.0.0",
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0",
-    "firebase": "^10.12.4",
-    "react-router-dom": "^6.26.2"
-
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.3.0",


### PR DESCRIPTION
## Summary
- refactor `asArray` to support typed arrays and update callers to pass typed query data
- relax analyse scan result typing and clean up helper comments for TypeScript compatibility
- add uuid typings dependency so shared schema builds without errors

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e2ebe10e788323b18f61ca7dcf0d26