### PR TITLE
Handle unknown errors in unauthorized helper

### DIFF
--- a/client/src/lib/authUtils.ts
+++ b/client/src/lib/authUtils.ts
@@ -1,3 +1,7 @@
-export function isUnauthorizedError(error: Error): boolean {
+export function isUnauthorizedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
   return /^401: .*Unauthorized/.test(error.message);
 }

--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -315,7 +315,7 @@ export default function Analyse() {
       } catch (error) {
         if (lastRequestIdRef.current !== rid) return;
 
-        if (error instanceof Error && isUnauthorizedError(error)) {
+        if (isUnauthorizedError(error)) {
           toast.dismiss(ANALYSE_TOAST_ID);
           toast({
             title: "Sign in required",
@@ -449,7 +449,7 @@ export default function Analyse() {
       queryClient.invalidateQueries({ queryKey: ["watchlist"] });
     },
     onError: (error: unknown) => {
-      if (error instanceof Error && isUnauthorizedError(error)) {
+      if (isUnauthorizedError(error)) {
         toast({
           title: "Sign in required",
           description: "Please sign in to manage your watchlist.",
@@ -481,7 +481,7 @@ export default function Analyse() {
       queryClient.invalidateQueries({ queryKey: ["watchlist"] });
     },
     onError: (error: unknown) => {
-      if (error instanceof Error && isUnauthorizedError(error)) {
+      if (isUnauthorizedError(error)) {
         toast({
           title: "Sign in required",
           description: "Please sign in to manage your watchlist.",

--- a/client/src/pages/charts.original.backup.tsx
+++ b/client/src/pages/charts.original.backup.tsx
@@ -176,7 +176,7 @@ export default function Charts() {
       setScanResult(data);
     },
     onError: (error: unknown) => {
-      if (error instanceof Error && isUnauthorizedError(error)) {
+      if (isUnauthorizedError(error)) {
         toast({
           title: "Unauthorized",
           description: "You are logged out. Logging in again...",

--- a/client/src/pages/charts.tsx
+++ b/client/src/pages/charts.tsx
@@ -243,7 +243,7 @@ export default function Charts() {
       queryClient.invalidateQueries({ queryKey: ["scan-history"] });
     },
     onError: (error: unknown) => {
-      if (error instanceof Error && isUnauthorizedError(error)) {
+      if (isUnauthorizedError(error)) {
         toast({
           title: "Sign in required",
           description: "Please sign back in to analyze symbols.",
@@ -360,7 +360,7 @@ export default function Charts() {
       queryClient.invalidateQueries({ queryKey: ["watchlist"] });
     },
     onError: (error: unknown) => {
-      if (error instanceof Error && isUnauthorizedError(error)) {
+      if (isUnauthorizedError(error)) {
         toast({
           title: "Sign in required",
           description: "Please sign in to manage your watchlist.",
@@ -392,7 +392,7 @@ export default function Charts() {
       queryClient.invalidateQueries({ queryKey: ["watchlist"] });
     },
     onError: (error: unknown) => {
-      if (error instanceof Error && isUnauthorizedError(error)) {
+      if (isUnauthorizedError(error)) {
         toast({
           title: "Sign in required",
           description: "Please sign in to manage your watchlist.",


### PR DESCRIPTION
## Summary
- allow isUnauthorizedError to accept unknown values by guarding with instanceof Error
- rely on the shared helper in charts and analyse catch blocks instead of duplicating instanceof checks

## Testing
- npm run check *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ed25e3788323988b75ebb2b6ef97