### PR TITLE
Refine WebSocket shim typing

### DIFF
--- a/client/src/lib/disableLocalWs.ts
+++ b/client/src/lib/disableLocalWs.ts
@@ -38,11 +38,10 @@
       /* fall through to real WS */
     }
     // Everything else (like Binance) goes through as normal
-    return new NativeWS(url, protocols);
+    return new NativeWS(url as any, protocols);
   }
 
   // Keep prototype so instanceof checks and event APIs keep working
-  (PatchedWS as any).prototype = NativeWS.prototype;
-  // @ts-expect-error: override global
-  window.WebSocket = PatchedWS;
+  (PatchedWS as unknown as { prototype: WebSocket }).prototype = NativeWS.prototype;
+  window.WebSocket = PatchedWS as unknown as typeof window.WebSocket;
 })();


### PR DESCRIPTION
## Summary
- replace the WebSocket shim's suppression with targeted casts while preserving runtime behaviour

## Testing
- npm run check *(fails: Cannot find module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_68e2edf877dc8323b63500cf5e5e5bda