### PR TITLE
Fix Market Overview CTA buttons to render as anchors

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -459,8 +459,12 @@ export default function Home() {
                 </div>
               </div>
               <div className="mt-4 flex space-x-2">
-                <Link href="/portfolio"><Button size="sm" data-testid="button-view-portfolio">View Portfolio</Button></Link>
-                <Link href="/charts"><Button size="sm" variant="outline" data-testid="button-start-scanning">Start Scanning</Button></Link>
+                <Button asChild size="sm" data-testid="button-view-portfolio">
+                  <Link href="/portfolio">View Portfolio</Link>
+                </Button>
+                <Button asChild size="sm" variant="outline" data-testid="button-start-scanning">
+                  <Link href="/charts">Start Scanning</Link>
+                </Button>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- convert the Market Overview call-to-action buttons to render their Next.js `Link` elements via `Button asChild`
- remove nested interactive elements while retaining the existing button styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e304c66d8c832391f5325d628fffe6