### PR TITLE
Refine analyse page layout

### DIFF
--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -813,74 +813,68 @@ export default function Analyse() {
         </div>
       </header>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
-        <Card className="h-full">
-          <CardContent className="space-y-4 pt-6">
-            <div className="grid grid-cols-1 gap-3 lg:grid-cols-[minmax(0,4fr)_minmax(0,1fr)] lg:items-center lg:gap-4">
-              <div className="flex w-full items-center gap-2">
-                <div className="relative flex-1 min-w-[280px]">
-                  <Input
-                    placeholder="Enter coin (BTC, ETH, SOL...)"
-                    value={searchInput}
-                    onChange={(e) => setSearchInput(e.target.value)}
-                    onKeyPress={handleKeyPress}
-                    className="h-11 pl-10"
-                    data-testid="input-search-symbol"
-                    disabled={!isAuthenticated || !networkEnabled}
-                  />
-                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                </div>
-                <Button
-                  onClick={handleSearch}
-                  variant="outline"
-                  className="h-11 w-11 min-w-11 p-0"
-                  data-testid="button-search-coin"
+      <div className="grid grid-cols-12 gap-4">
+        <section className="col-span-9 bg-[#111214] rounded-2xl border border-zinc-800 p-4 h-[140px] flex flex-col justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex-1 min-w-0">
+              <div className="relative w-full">
+                <Input
+                  placeholder="Enter coin (BTC, ETH, SOL...)"
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  onKeyPress={handleKeyPress}
+                  className="h-11 w-full min-w-0 pl-10"
+                  data-testid="input-search-symbol"
                   disabled={!isAuthenticated || !networkEnabled}
-                >
-                  <Search className="h-4 w-4" />
-                </Button>
-              </div>
-
-              <div className="flex w-full flex-col items-stretch gap-2 lg:col-start-2 lg:flex-row lg:items-center lg:justify-end lg:gap-3">
-                <div className="flex w-full items-center gap-2 lg:w-auto lg:justify-end">
-                  <label className="text-sm font-medium text-foreground">Timeframe</label>
-                  <Select value={selectedTimeframe} onValueChange={setSelectedTimeframe}>
-                    <SelectTrigger className="h-11 w-full min-w-[160px] lg:w-48" data-testid="select-timeframe">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {TIMEFRAMES.map((tf) => (
-                        <SelectItem key={tf.value} value={tf.value}>
-                          {tf.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <Button
-                  onClick={handleScan}
-                  disabled={isScanning || !isAuthenticated || !networkEnabled}
-                  className="h-11 w-full bg-primary text-primary-foreground hover:bg-primary/90 lg:w-auto"
-                  data-testid="button-scan"
-                >
-                  <RefreshCw className={`mr-2 h-4 w-4 ${isScanning ? "animate-spin" : ""}`} />
-                  {isScanning ? "Scanning..." : "Run Analysis"}
-                </Button>
+                />
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               </div>
             </div>
-
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Activity className="h-3 w-3" />
-              Currently viewing <span className="font-medium text-foreground">{displayPair(selectedSymbol)}</span>
-              <span className="text-muted-foreground">
+            <Button
+              onClick={handleScan}
+              disabled={isScanning || !isAuthenticated || !networkEnabled}
+              className="h-11 whitespace-nowrap bg-primary px-4 text-primary-foreground hover:bg-primary/90"
+              data-testid="button-scan"
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${isScanning ? "animate-spin" : ""}`} />
+              {isScanning ? "Scanning..." : "Run Analysis"}
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Clock3 className="h-4 w-4" />
+              <span className="whitespace-nowrap">Timeframe</span>
+              <Select value={selectedTimeframe} onValueChange={setSelectedTimeframe}>
+                <SelectTrigger
+                  className="h-9 min-w-[140px] border-zinc-700 bg-[#15161a] text-left text-foreground"
+                  data-testid="select-timeframe"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIMEFRAMES.map((tf) => (
+                    <SelectItem key={tf.value} value={tf.value}>
+                      {tf.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex min-w-0 items-center gap-2">
+              <Activity className="h-4 w-4" />
+              <Badge className="truncate bg-zinc-800/80 px-2 py-1 text-xs font-medium uppercase text-foreground">
+                {displayPair(selectedSymbol)}
+              </Badge>
+              <span className="whitespace-nowrap text-xs">
                 ({timeframeConfig?.display ?? selectedTimeframe})
               </span>
             </div>
-          </CardContent>
-        </Card>
+          </div>
+        </section>
 
-        {overallAnalysisCard}
+        <aside className="col-span-12 lg:col-span-3">
+          {overallAnalysisCard}
+        </aside>
       </div>
 
       {priceSummaryCards}


### PR DESCRIPTION
## Summary
- replace the analyse page hero grid with a 12-column layout using a section for controls and an aside for the overall analysis card
- rework the header controls into two flexible rows that keep the search, run analysis button, timeframe selector, and symbol badge within the fixed-height panel

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e3c023bcd8832398af87f63a2d3ed9