### PR TITLE
Refine analyse layout and share overall analysis card

### DIFF
--- a/client/src/features/analyse/OverallAnalysisCard.tsx
+++ b/client/src/features/analyse/OverallAnalysisCard.tsx
@@ -1,0 +1,91 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+import { Search } from "lucide-react";
+
+import {
+  getRecommendationColor,
+  getScoreBorderTone,
+  getScoreColor,
+  type Recommendation,
+} from "./utils";
+
+interface OverallAnalysisCardProps {
+  score: number;
+  recommendation: Recommendation | string;
+  recommendationLabel: string;
+  hasResult: boolean;
+  confidenceLabel?: string;
+  className?: string;
+}
+
+export function OverallAnalysisCard({
+  score,
+  recommendation,
+  recommendationLabel,
+  hasResult,
+  confidenceLabel,
+  className,
+}: OverallAnalysisCardProps) {
+  const normalizedRecommendation = recommendation?.toString().toLowerCase();
+  const badgeClass = getRecommendationColor(normalizedRecommendation);
+  const progressValue = Math.max(0, Math.min(100, ((score + 30) / 60) * 100));
+  const confidence = confidenceLabel ?? recommendationLabel;
+
+  return (
+    <Card
+      className={cn(
+        "h-full border-2 bg-card/70",
+        hasResult ? getScoreBorderTone(score) : "border-border/60",
+        className,
+      )}
+    >
+      <CardContent className="h-full p-6">
+        {hasResult ? (
+          <div className="flex h-full min-h-[220px] flex-col justify-between gap-4">
+            <div className="space-y-4">
+              <div>
+                <p className="text-sm text-muted-foreground">Overall Analysis</p>
+                <div className="mt-2 flex items-center space-x-2">
+                  <span
+                    className={cn("text-2xl font-bold leading-none", getScoreColor(score))}
+                    data-testid="text-total-score"
+                  >
+                    {score > 0 ? "+" : ""}
+                    {score}
+                  </span>
+                  <Badge
+                    className={cn(badgeClass, "px-2 py-1 text-xs")}
+                    data-testid="badge-recommendation"
+                  >
+                    {recommendationLabel}
+                  </Badge>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Progress value={progressValue} className="h-2" />
+                <p className="text-xs text-muted-foreground">Range: -30 to +30</p>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Confidence</span>
+              <span className="text-foreground">{confidence}</span>
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full min-h-[220px] flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+            <Search className="h-10 w-10 text-muted-foreground/60" />
+            <div>
+              <p className="text-lg font-semibold text-foreground">No analysis yet</p>
+              <p className="text-sm text-muted-foreground">
+                Run a scan to unlock overall recommendations.
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/features/analyse/utils.ts
+++ b/client/src/features/analyse/utils.ts
@@ -1,0 +1,43 @@
+export type Recommendation = "strong_buy" | "buy" | "hold" | "sell" | "strong_sell";
+
+export function getScoreColor(score: number) {
+  if (score >= 10) return "text-green-600";
+  if (score >= 5) return "text-green-500";
+  if (score <= -10) return "text-red-600";
+  if (score <= -5) return "text-red-500";
+  return "text-yellow-500";
+}
+
+export function getScoreBorderTone(score: number) {
+  if (score >= 5) return "border-green-500/80";
+  if (score <= -5) return "border-red-500/80";
+  return "border-yellow-500/80";
+}
+
+export function getRecommendationColor(recommendation: string) {
+  switch (recommendation.toLowerCase() as Recommendation) {
+    case "strong_buy":
+      return "bg-green-600 text-white";
+    case "buy":
+      return "bg-green-500 text-white";
+    case "strong_sell":
+      return "bg-red-600 text-white";
+    case "sell":
+      return "bg-red-500 text-white";
+    default:
+      return "bg-yellow-500 text-black";
+  }
+}
+
+export function confidenceToRecommendation(confidence: string): Recommendation {
+  switch (confidence) {
+    case "High":
+      return "strong_buy";
+    case "Medium":
+      return "buy";
+    case "Watch":
+      return "hold";
+    default:
+      return "hold";
+  }
+}


### PR DESCRIPTION
## Summary
- extract a reusable `OverallAnalysisCard` feature component with shared styling helpers
- update the analyse page to adopt the shared card while aligning the toolbar/layout with upstream tweaks
- add scoring/recommendation utility helpers for analyse-related views

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c67a850883239f1292f5482b0da3