### PR TITLE
Refactor scan result extraction into shared helper

### DIFF
--- a/client/src/lib/scanner-results.ts
+++ b/client/src/lib/scanner-results.ts
@@ -1,0 +1,28 @@
+import type { ScanResult } from "@shared/types/scanner";
+
+export type ExtractableScanResult = { symbol?: unknown };
+
+export function extractScanResult<T extends ExtractableScanResult = ScanResult>(
+  payload: unknown,
+): T | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const withData = payload as { data?: unknown };
+
+  if (Array.isArray(withData.data)) {
+    const [first] = withData.data as unknown[];
+    return first && typeof first === "object" ? (first as T) : null;
+  }
+
+  if (withData.data && typeof withData.data === "object") {
+    return extractScanResult<T>(withData.data);
+  }
+
+  if ((payload as ExtractableScanResult)?.symbol) {
+    return payload as T;
+  }
+
+  return null;
+}

--- a/client/src/pages/analyse.tsx
+++ b/client/src/pages/analyse.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { asArray, asString } from "@/lib/utils";
+import { extractScanResult } from "@/lib/scanner-results";
 import {
   BreakdownSection,
   type BreakdownRow,
@@ -156,30 +157,6 @@ function clearWindowSearch() {
 
   url.search = "";
   window.history.replaceState(null, "", url.toString());
-}
-
-function extractScanResult(payload: unknown): ScannerAnalysis | ScanResult | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-
-  const withData = payload as { data?: unknown };
-  if (withData.data && Array.isArray(withData.data)) {
-    const [first] = withData.data as unknown[];
-    return (first && typeof first === "object")
-      ? (first as ScannerAnalysis | ScanResult)
-      : null;
-  }
-
-  if (withData.data && typeof withData.data === "object") {
-    return extractScanResult(withData.data);
-  }
-
-  if ((payload as ScannerAnalysis | ScanResult)?.symbol) {
-    return payload as ScannerAnalysis | ScanResult;
-  }
-
-  return null;
 }
 
 function formatIndicatorLabel(key: string) {
@@ -408,7 +385,7 @@ export default function Analyse() {
 
         if (lastRequestIdRef.current !== rid) return;
 
-        const item = extractScanResult(payload);
+        const item = extractScanResult<ScannerAnalysis | ScanResult>(payload);
         if (!item) {
           toast.error("Analysis unavailable", { id: ANALYSE_TOAST_ID });
           setScanResult(null);


### PR DESCRIPTION
## Summary
- move the scan result extraction logic into a shared utility that normalizes scanner API responses
- update the analyse and charts pages to consume the shared helper and align success/error handling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e438e8b2008323aeaf84a7d6a9d029