### PR TITLE
Add AnalyseV2 sandbox terminal layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,8 +19,10 @@ import Gainers from "@/pages/gainers";
 import AIInsights from "@/pages/ai-insights";
 import Charts from "@/pages/charts";
 import Analyse from "@/pages/analyse";
+import AnalyseV2 from "@/pages/AnalyseV2";
 import Watchlist from "@/pages/watchlist";
 import Alerts from "@/pages/alerts";
+import { CreditProvider } from "@/stores/creditStore";
 
 // (keep for later) Protected HOC
 function Protected<T extends React.ComponentType<any>>(Component: T) {
@@ -79,6 +81,7 @@ function Router() {
 
       {/* ANALYSE */}
       <Route path="/analyse/:symbol?" component={withLayout(Analyse)} />
+      <Route path="/analyse-v2/:symbol?" component={withLayout(AnalyseV2)} />
 
       {/* CHARTS */}
       <Route path="/charts/:symbol?" component={withLayout(Charts)} />
@@ -92,12 +95,14 @@ function Router() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider defaultTheme="dark" storageKey="cryptotrader-theme">
-        <TooltipProvider>
-          <Toaster />
-          <Router />
-        </TooltipProvider>
-      </ThemeProvider>
+      <CreditProvider>
+        <ThemeProvider defaultTheme="dark" storageKey="cryptotrader-theme">
+          <TooltipProvider>
+            <Toaster />
+            <Router />
+          </TooltipProvider>
+        </ThemeProvider>
+      </CreditProvider>
     </QueryClientProvider>
   );
 }

--- a/client/src/components/analyse-v2/AISummaryPanel.module.css
+++ b/client/src/components/analyse-v2/AISummaryPanel.module.css
@@ -1,0 +1,102 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 12px;
+  gap: 12px;
+}
+
+.badges {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.badge {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  padding: 4px 8px;
+  letter-spacing: 0.3px;
+}
+
+.summary {
+  font-size: 12px;
+  line-height: 1.4;
+  color: #d9d9d9;
+}
+
+.planGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  padding: 10px;
+  font-size: 12px;
+}
+
+.planCell {
+  display: grid;
+  gap: 4px;
+}
+
+.planLabel {
+  text-transform: uppercase;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.list {
+  padding-left: 16px;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.actionButton {
+  flex: 1;
+  min-width: 120px;
+  background: #202020;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  color: #f4f4f4;
+  transition: background 0.2s ease;
+}
+
+.actionButton:hover:not(.disabled) {
+  background: #2a2a2a;
+}
+
+.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.spinner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: rgba(255, 255, 255, 0.8);
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/client/src/components/analyse-v2/AISummaryPanel.tsx
+++ b/client/src/components/analyse-v2/AISummaryPanel.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import styles from "./AISummaryPanel.module.css";
+import { useToast } from "@/hooks/use-toast";
+import { useCreditStore } from "@/stores/creditStore";
+
+type AISummaryPanelProps = {
+  symbol: string;
+  tf: string;
+};
+
+type Action = {
+  key: string;
+  label: string;
+  cost: number;
+};
+
+const actions: Action[] = [
+  { key: "analyse", label: "Analyse", cost: 2 },
+  { key: "summary", label: "AI Summary", cost: 5 },
+  { key: "multitf", label: "Multi-TF", cost: 15 },
+];
+
+export function AISummaryPanel({ symbol, tf }: AISummaryPanelProps) {
+  const { canSpend, consume } = useCreditStore();
+  const { toast } = useToast();
+  const [loadingKey, setLoadingKey] = useState<string | null>(null);
+
+  const handleAction = (action: Action) => {
+    if (loadingKey) return;
+
+    if (!canSpend(action.cost)) {
+      toast({
+        title: "Not enough credits",
+        description: "Top up credits to continue running AI actions.",
+      });
+      return;
+    }
+
+    consume(action.cost);
+    setLoadingKey(action.key);
+    setTimeout(() => {
+      setLoadingKey(null);
+    }, 600);
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.badges}>
+        <span className={styles.badge}>Source: Heuristic</span>
+        <span className={styles.badge}>Confidence: Med</span>
+      </div>
+
+      <div className={styles.summary}>
+        Momentum is stabilising after a corrective pullback. Watch for bids to
+        hold the 1h mid-range before continuation. Macro structure remains
+        constructive while spot demand stays elevated.
+      </div>
+
+      <div className={styles.planGrid}>
+        <div className={styles.planCell}>
+          <span className={styles.planLabel}>Entry</span>
+          <span>{symbol.toUpperCase()} @ 29.40</span>
+        </div>
+        <div className={styles.planCell}>
+          <span className={styles.planLabel}>Target</span>
+          <span>31.80 (R2)</span>
+        </div>
+        <div className={styles.planCell}>
+          <span className={styles.planLabel}>Stop</span>
+          <span>28.60 swing low</span>
+        </div>
+      </div>
+
+      <div>
+        <div className={styles.planLabel}>Risks</div>
+        <ul className={styles.list}>
+          <li>High timeframe trendline overhead near 32.10.</li>
+          <li>Funding turning positive may invite late longs.</li>
+          <li>Liquidity pockets below 28.80 remain untested.</li>
+        </ul>
+      </div>
+
+      <div className={styles.actions}>
+        {actions.map((action) => {
+          const disabled = loadingKey !== null && loadingKey !== action.key;
+          return (
+            <button
+              key={action.key}
+              className={`${styles.actionButton} ${disabled ? styles.disabled : ""}`}
+              onClick={() => handleAction(action)}
+              disabled={disabled}
+            >
+              {loadingKey === action.key ? <span className={styles.spinner} /> : action.label}
+              {loadingKey !== action.key && <span>({action.cost} credits)</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ fontSize: 11, opacity: 0.65, textTransform: "uppercase" }}>
+        {tf.toUpperCase()} focus · Mock output for preview only
+      </div>
+    </div>
+  );
+}
+
+export default AISummaryPanel;

--- a/client/src/components/analyse-v2/ChartPanel.module.css
+++ b/client/src/components/analyse-v2/ChartPanel.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.tabs {
+  display: flex;
+  gap: 12px;
+  padding: 10px 12px 0 12px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.tab {
+  opacity: 0.6;
+  cursor: pointer;
+}
+
+.tabActive {
+  opacity: 1;
+  position: relative;
+}
+
+.tabActive::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 2px;
+  background: #3fb950;
+  border-radius: 4px;
+}
+
+.canvas {
+  flex: 1;
+  margin: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 14px;
+  min-height: 65vh;
+}

--- a/client/src/components/analyse-v2/ChartPanel.tsx
+++ b/client/src/components/analyse-v2/ChartPanel.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styles from "./ChartPanel.module.css";
+
+type ChartPanelProps = {
+  symbol: string;
+  tf: string;
+};
+
+export function ChartPanel({ symbol, tf }: ChartPanelProps) {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.tabs}>
+        <span className={`${styles.tab} ${styles.tabActive}`}>Chart</span>
+        <span className={styles.tab}>Info</span>
+        <span className={styles.tab}>Depth</span>
+      </div>
+      <div className={styles.canvas}>
+        <div>
+          <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.4 }}>
+            {symbol.toUpperCase()} · {tf.toUpperCase()}
+          </div>
+          <div style={{ marginTop: 8, fontSize: 16 }}>Chart goes here</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ChartPanel;

--- a/client/src/components/analyse-v2/TechnicalPanel.module.css
+++ b/client/src/components/analyse-v2/TechnicalPanel.module.css
@@ -1,0 +1,41 @@
+.list {
+  list-style: none;
+  padding: 10px;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.label {
+  color: #c8c8c8;
+}
+
+.value {
+  color: #f5f5f5;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.meta {
+  opacity: 0.75;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+}
+
+.labelWrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}

--- a/client/src/components/analyse-v2/TechnicalPanel.tsx
+++ b/client/src/components/analyse-v2/TechnicalPanel.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styles from "./TechnicalPanel.module.css";
+
+type TechnicalPanelProps = {
+  symbol: string;
+  tf: string;
+};
+
+type Metric = {
+  label: string;
+  value: string;
+  status: "bullish" | "neutral" | "bearish";
+};
+
+const statusColor: Record<Metric["status"], string> = {
+  bullish: "#3fb950",
+  neutral: "#f2c744",
+  bearish: "#f85149",
+};
+
+const mockMetrics: Metric[] = [
+  { label: "RSI (14)", value: "48 · Neutral", status: "neutral" },
+  { label: "MACD", value: "Signal +0.6", status: "bullish" },
+  { label: "ADX", value: "24 · Trend Weak", status: "neutral" },
+  { label: "EMA Stack", value: "50 > 100 > 200", status: "bullish" },
+  { label: "EMA Distance", value: "+2.8%", status: "bullish" },
+  { label: "ATR %", value: "3.1%", status: "neutral" },
+  { label: "Vol. Z-Score", value: "+1.8", status: "bullish" },
+  { label: "SR Proximity", value: "-1.3% from R", status: "bearish" },
+  { label: "Trend Score", value: "62 / 100", status: "bullish" },
+  { label: "Momentum", value: "Cooling", status: "bearish" },
+  { label: "Liquidity", value: "Healthy", status: "bullish" },
+  { label: "Funding", value: "0.013%", status: "neutral" },
+  { label: "OI Drift", value: "+4%", status: "bullish" },
+  { label: "Volatility", value: "Contracting", status: "bearish" },
+];
+
+export function TechnicalPanel({ symbol, tf }: TechnicalPanelProps) {
+  return (
+    <div>
+      <ul className={styles.list}>
+        <li className={styles.meta}>{symbol.toUpperCase()} · {tf.toUpperCase()} snapshot</li>
+        {mockMetrics.map((metric) => (
+          <li key={metric.label} className={styles.row}>
+            <span className={styles.labelWrap}>
+              <span
+                className={styles.dot}
+                style={{ backgroundColor: statusColor[metric.status] }}
+              />
+              <span className={styles.label}>{metric.label}</span>
+            </span>
+            <span className={styles.value}>{metric.value}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default TechnicalPanel;

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -26,17 +26,26 @@ function SidebarItem({
   to,
   activeWhen,
   children,
+  style,
 }: {
   to: string;
   activeWhen?: string | RegExp;
   children: React.ReactNode;
+  style?: React.CSSProperties;
 }) {
   const [location] = useLocation();
   const activeMatch =
     activeWhen !== undefined ? isActivePath(location, activeWhen) : location === to;
 
   return (
-    <Link to={to} style={activeMatch ? { ...baseLink, ...active } : baseLink}>
+    <Link
+      to={to}
+      style={
+        activeMatch
+          ? { ...baseLink, ...style, ...active }
+          : { ...baseLink, ...style }
+      }
+    >
       {children}
     </Link>
   );
@@ -63,6 +72,13 @@ export function Sidebar() {
         {/* Analyse (single menu item, active for /charts or /analyse) */}
         <SidebarItem to="/analyse" activeWhen={/^\/(charts|analyse)(\/|$)/}>
           Analyse
+        </SidebarItem>
+        <SidebarItem
+          to="/analyse-v2"
+          activeWhen={/^\/analyse-v2(\/|$)/}
+          style={{ marginLeft: 12, fontSize: 14 }}
+        >
+          Analyse v2 (beta)
         </SidebarItem>
 
         {/* Gainers */}

--- a/client/src/pages/AnalyseV2.module.css
+++ b/client/src/pages/AnalyseV2.module.css
@@ -1,0 +1,133 @@
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 2.2fr 1.2fr;
+  gap: 10px;
+  height: calc(100vh - 80px);
+  min-height: 600px;
+  padding: 10px;
+}
+
+.panel {
+  background: var(--card-bg, #121212);
+  border: 1px solid var(--card-border, #2a2a2a);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.panelTechnical {
+}
+
+.panelChart {
+}
+
+.panelAI {
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--card-border, #2a2a2a);
+  font-size: 11px;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.panelBody {
+  flex: 1;
+  overflow: auto;
+}
+
+.dense {
+  font-size: 12px;
+  line-height: 1.2;
+}
+
+.dense p,
+.dense li {
+  margin: 4px 0;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  padding-top: 0;
+  font-size: 12px;
+}
+
+.toolbarForm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.input {
+  background: #0e0e0e;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  padding: 6px 8px;
+  color: #f0f0f0;
+  font-size: 12px;
+  width: 140px;
+}
+
+.select {
+  background: #0e0e0e;
+  border: 1px solid #2a2a2a;
+  border-radius: 6px;
+  padding: 6px 8px;
+  color: #f0f0f0;
+  font-size: 12px;
+}
+
+.button {
+  background: #1f1f1f;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: #f5f5f5;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.button:hover {
+  background: #2a2a2a;
+}
+
+.chip {
+  background: rgba(80, 80, 80, 0.25);
+  border-radius: 12px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: #dcdcdc;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .toolbar {
+    flex-wrap: wrap;
+  }
+
+  .panelChart {
+    order: 1;
+  }
+
+  .panelAI {
+    order: 2;
+  }
+
+  .panelTechnical {
+    order: 3;
+  }
+}

--- a/client/src/pages/AnalyseV2.tsx
+++ b/client/src/pages/AnalyseV2.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+import styles from "./AnalyseV2.module.css";
+import { TechnicalPanel } from "@/components/analyse-v2/TechnicalPanel";
+import { ChartPanel } from "@/components/analyse-v2/ChartPanel";
+import { AISummaryPanel } from "@/components/analyse-v2/AISummaryPanel";
+import { useCreditStore } from "@/stores/creditStore";
+
+type Timeframe = "1h" | "4h" | "1d";
+
+const timeframeOptions: Timeframe[] = ["1h", "4h", "1d"];
+
+export default function AnalyseV2() {
+  const [symbol, setSymbol] = useState("INJUSDT");
+  const [inputValue, setInputValue] = useState("INJUSDT");
+  const [timeframe, setTimeframe] = useState<Timeframe>("1h");
+  const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const { credits } = useCreditStore();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextSymbol = inputValue.trim();
+    if (!nextSymbol) return;
+    setSymbol(nextSymbol.toUpperCase());
+  };
+
+  const handleRefresh = () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    setLastRefreshed(new Date());
+    setTimeout(() => {
+      setIsRefreshing(false);
+    }, 600);
+  };
+
+  return (
+    <div>
+      <div className={styles.toolbar}>
+        <form className={styles.toolbarForm} onSubmit={handleSubmit}>
+          <input
+            className={styles.input}
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value.toUpperCase())}
+            placeholder="Symbol"
+            aria-label="Symbol"
+          />
+          <button type="submit" className={styles.button}>
+            Search
+          </button>
+        </form>
+
+        <select
+          className={styles.select}
+          value={timeframe}
+          onChange={(event) => setTimeframe(event.target.value as Timeframe)}
+          aria-label="Timeframe"
+        >
+          {timeframeOptions.map((option) => (
+            <option key={option} value={option}>
+              {option.toUpperCase()}
+            </option>
+          ))}
+        </select>
+
+        <button type="button" className={styles.button} onClick={handleRefresh}>
+          {isRefreshing ? "Refreshing…" : "Refresh"}
+        </button>
+
+        <div className={styles.chip}>Credits: {credits}</div>
+        {lastRefreshed && (
+          <div style={{ fontSize: 11, opacity: 0.6 }}>
+            Synced {lastRefreshed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          </div>
+        )}
+      </div>
+
+      <div className={styles.layout}>
+        <section className={`${styles.panel} ${styles.panelTechnical} ${styles.dense}`}>
+          <div className={styles.panelHeader}>Technical Breakdown</div>
+          <div className={styles.panelBody}>
+            <TechnicalPanel symbol={symbol} tf={timeframe} />
+          </div>
+        </section>
+
+        <section className={`${styles.panel} ${styles.panelChart}`}>
+          <div className={styles.panelHeader}>Chart</div>
+          <div className={styles.panelBody}>
+            <ChartPanel symbol={symbol} tf={timeframe} />
+          </div>
+        </section>
+
+        <section className={`${styles.panel} ${styles.panelAI} ${styles.dense}`}>
+          <div className={styles.panelHeader}>
+            <span>AI Summary</span>
+            <span style={{ opacity: 0.7 }}>Credits: {credits}</span>
+          </div>
+          <div className={styles.panelBody}>
+            <AISummaryPanel symbol={symbol} tf={timeframe} />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/stores/creditStore.tsx
+++ b/client/src/stores/creditStore.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+type CreditContextValue = {
+  credits: number;
+  canSpend: (amount: number) => boolean;
+  consume: (amount: number) => boolean;
+};
+
+const CreditContext = createContext<CreditContextValue | undefined>(undefined);
+
+export function CreditProvider({ children }: { children: React.ReactNode }) {
+  const [credits, setCredits] = useState(20);
+
+  const canSpend = useCallback(
+    (amount: number) => {
+      return credits >= amount;
+    },
+    [credits],
+  );
+
+  const consume = useCallback((amount: number) => {
+    let success = false;
+    setCredits((previous) => {
+      if (previous >= amount) {
+        success = true;
+        return previous - amount;
+      }
+      return previous;
+    });
+    return success;
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      credits,
+      canSpend,
+      consume,
+    }),
+    [credits, canSpend, consume],
+  );
+
+  return <CreditContext.Provider value={value}>{children}</CreditContext.Provider>;
+}
+
+export function useCreditStore() {
+  const context = useContext(CreditContext);
+  if (!context) {
+    throw new Error("useCreditStore must be used within a CreditProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add the AnalyseV2 sandbox page with a terminal-style grid layout and compact toolbar
- create mock technical, chart, and AI summary panels wired to the shared credit store
- expose the new route, sidebar link, and wrap the app with the credit provider

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53586b0248323acbc3c91d7ff253e