### PR TITLE
Separate Analyse V2 left column cards

### DIFF
--- a/client/src/components/analyse-v2/LeftControlBox.module.css
+++ b/client/src/components/analyse-v2/LeftControlBox.module.css
@@ -1,14 +1,14 @@
 .card {
   position: sticky;
   top: 8px;
-  z-index: 2;
+  z-index: 3;
   background: var(--card-bg, #101010);
   border: 1px solid var(--card-border, #2a2a2a);
   border-radius: 10px;
   padding: 10px;
-  margin-bottom: 10px;
   font-size: 12px;
   line-height: 1.2;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.02) inset;
 }
 
 .label {
@@ -100,8 +100,6 @@
   align-items: center;
   gap: 8px;
   margin-top: 6px;
-  padding-top: 6px;
-  border-top: 1px dashed var(--card-border, #2a2a2a);
   color: #bdbdbd;
 }
 

--- a/client/src/components/analyse-v2/TechnicalPanel.module.css
+++ b/client/src/components/analyse-v2/TechnicalPanel.module.css
@@ -1,16 +1,61 @@
-.list {
-  list-style: none;
+.card {
+  background: var(--card-bg, #101010);
+  border: 1px solid var(--card-border, #2a2a2a);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+.header {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--card-border, #2a2a2a);
+  font-size: 11px;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.body {
+  flex: 1;
   padding: 10px;
-  margin: 0;
-  display: grid;
-  gap: 6px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.subtle {
+  color: #9aa0a6;
+  margin-bottom: 6px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
 }
 
 .row {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding: 6px 0;
   gap: 12px;
+}
+
+.row + .row {
+  border-top: 1px dashed var(--card-border, #2a2a2a);
+}
+
+.labelWrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
 }
 
 .label {
@@ -21,21 +66,4 @@
   color: #f5f5f5;
   text-align: right;
   font-variant-numeric: tabular-nums;
-}
-
-.meta {
-  opacity: 0.75;
-}
-
-.dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin-right: 6px;
-}
-
-.labelWrap {
-  display: flex;
-  align-items: center;
-  gap: 6px;
 }

--- a/client/src/components/analyse-v2/TechnicalPanel.tsx
+++ b/client/src/components/analyse-v2/TechnicalPanel.tsx
@@ -37,22 +37,27 @@ const mockMetrics: Metric[] = [
 
 export function TechnicalPanel({ symbol, tf }: TechnicalPanelProps) {
   return (
-    <div>
-      <ul className={styles.list}>
-        <li className={styles.meta}>{symbol.toUpperCase()} · {tf.toUpperCase()} snapshot</li>
-        {mockMetrics.map((metric) => (
-          <li key={metric.label} className={styles.row}>
-            <span className={styles.labelWrap}>
-              <span
-                className={styles.dot}
-                style={{ backgroundColor: statusColor[metric.status] }}
-              />
-              <span className={styles.label}>{metric.label}</span>
-            </span>
-            <span className={styles.value}>{metric.value}</span>
-          </li>
-        ))}
-      </ul>
+    <div className={styles.card} role="region" aria-label="Technical breakdown">
+      <div className={styles.header}>TECHNICAL BREAKDOWN</div>
+      <div className={styles.body}>
+        <div className={styles.subtle}>
+          {symbol.toUpperCase()} · {tf.toUpperCase()} snapshot
+        </div>
+        <div className={styles.list}>
+          {mockMetrics.map((metric) => (
+            <div key={metric.label} className={styles.row}>
+              <span className={styles.labelWrap}>
+                <span
+                  className={styles.dot}
+                  style={{ backgroundColor: statusColor[metric.status] }}
+                />
+                <span className={styles.label}>{metric.label}</span>
+              </span>
+              <span className={styles.value}>{metric.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/src/pages/AnalyseV2.module.css
+++ b/client/src/pages/AnalyseV2.module.css
@@ -17,6 +17,23 @@
 }
 
 .panelTechnical {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
+  box-shadow: none;
+  min-height: 0;
+}
+
+.leftBody {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 8px;
+  height: 100%;
+  overflow: auto;
+  min-height: 0;
+  isolation: isolate;
 }
 
 .panelChart {
@@ -39,7 +56,7 @@
 
 .panelBody {
   flex: 1;
-  overflow: auto;
+  padding: 0;
 }
 
 .dense {

--- a/client/src/pages/AnalyseV2.tsx
+++ b/client/src/pages/AnalyseV2.tsx
@@ -17,8 +17,7 @@ export default function AnalyseV2() {
   return (
     <div className={styles.layout}>
       <section className={`${styles.panel} ${styles.panelTechnical} ${styles.dense}`}>
-        <div className={styles.panelHeader}>Technical Breakdown</div>
-        <div className={styles.panelBody}>
+        <div className={styles.leftBody}>
           <LeftControlBox
             symbol={symbol}
             timeframe={timeframe}


### PR DESCRIPTION
## Summary
- split the Analyse V2 left column into sticky controls and an independent technical card
- refresh technical panel markup and styles with its own header and scrollable body
- adjust shared layout styles to provide spacing and remove overlapping borders

## Testing
- npm run build *(fails: [vite]: Rollup failed to resolve import "zustand")*


------
https://chatgpt.com/codex/tasks/task_e_68e55516e3488323852cc24024705b54