### PR TITLE
Wire dual timeframe flow and AI overlay for Analyse v2

### DIFF
--- a/client/src/components/analyse-v2/AISummaryPanel.module.css
+++ b/client/src/components/analyse-v2/AISummaryPanel.module.css
@@ -6,6 +6,66 @@
   gap: 12px;
 }
 
+.overlayWrapper {
+  position: relative;
+  justify-content: center;
+}
+
+.overlayGhost {
+  flex: 1;
+  filter: blur(0px);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.overlayCta {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  gap: 12px;
+  padding: 12px;
+  text-align: center;
+  backdrop-filter: blur(2px);
+}
+
+.overlayButton {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(15, 15, 15, 0.85);
+  color: #fdfdfd;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 12px;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.overlayButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.overlayButton:not(:disabled):hover {
+  background: rgba(35, 35, 35, 0.9);
+}
+
+.overlayHelper {
+  font-size: 11px;
+  color: #c8c8c8;
+  line-height: 1.4;
+  max-width: 220px;
+}
+
+.emptyNeutral {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: #a7a7a7;
+  padding: 20px 10px;
+}
+
 .badges {
   display: flex;
   gap: 8px;

--- a/client/src/components/analyse-v2/AISummaryPanel.tsx
+++ b/client/src/components/analyse-v2/AISummaryPanel.tsx
@@ -6,6 +6,11 @@ type AISummaryPanelProps = {
   symbol: string;
   tf: string;
   data: AIPayload | null;
+  hasTechnical: boolean;
+  onRunAI: () => void;
+  aiDisabled: boolean;
+  aiTooltip: string;
+  isLoading: boolean;
 };
 
 const confidenceLabel: Record<AIPayload["confidence"], string> = {
@@ -14,17 +19,51 @@ const confidenceLabel: Record<AIPayload["confidence"], string> = {
   high: "High",
 };
 
-export function AISummaryPanel({ symbol, tf, data }: AISummaryPanelProps) {
+export function AISummaryPanel({
+  symbol,
+  tf,
+  data,
+  hasTechnical,
+  onRunAI,
+  aiDisabled,
+  aiTooltip,
+  isLoading,
+}: AISummaryPanelProps) {
   const lastRun = relativeTimeFrom(data?.generatedAt);
 
   if (!data) {
-    return (
-      <div className={styles.wrapper}>
-        <div className={styles.empty}>
-          <div className={styles.emptyTitle}>Run the AI report</div>
-          <div className={styles.emptySub}>
-            Generate the technical analysis with AI summary to see insights here.
+    if (!hasTechnical) {
+      return (
+        <div className={styles.wrapper}>
+          <div className={styles.emptyNeutral}>
+            <div className={styles.emptyTitle}>Run a scan to see AI insights here.</div>
           </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className={`${styles.wrapper} ${styles.overlayWrapper}`}>
+        <div className={styles.overlayGhost}>
+          <div className={styles.summary} style={{ opacity: 0.35 }}>
+            AI insights will appear here once generated.
+          </div>
+        </div>
+        <div className={styles.overlayCta}>
+          <button
+            type="button"
+            className={styles.overlayButton}
+            onClick={() => {
+              void onRunAI();
+            }}
+            disabled={aiDisabled}
+            title={aiTooltip}
+          >
+            {isLoading ? "Running…" : "Run Technical Analysis with AI (5 credits)"}
+          </button>
+          <p className={styles.overlayHelper}>
+            Generate the technical analysis with AI summary for deeper context.
+          </p>
         </div>
       </div>
     );

--- a/client/src/components/analyse-v2/ChartPanel.tsx
+++ b/client/src/components/analyse-v2/ChartPanel.tsx
@@ -5,12 +5,12 @@ type Timeframe = "15m" | "1h" | "4h" | "1d";
 type ChartPanelProps = {
   symbol: string;
   tf: Timeframe;
-  onChangeDisplayTf?: (tf: Timeframe) => void;
+  onChangeChartTf?: (tf: Timeframe) => void;
 };
 
 const TFS: Timeframe[] = ["15m", "1h", "4h", "1d"];
 
-export function ChartPanel({ symbol, tf, onChangeDisplayTf }: ChartPanelProps) {
+export function ChartPanel({ symbol, tf, onChangeChartTf }: ChartPanelProps) {
   return (
     <div className={styles.wrapper}>
       <div className={styles.tabs}>
@@ -25,7 +25,7 @@ export function ChartPanel({ symbol, tf, onChangeDisplayTf }: ChartPanelProps) {
               key={option}
               type="button"
               className={`${styles.tfBtn} ${tf === option ? styles.tfActive : ""}`}
-              onClick={() => onChangeDisplayTf?.(option)}
+              onClick={() => onChangeChartTf?.(option)}
             >
               {option}
             </button>

--- a/client/src/components/analyse-v2/TechnicalPanel.module.css
+++ b/client/src/components/analyse-v2/TechnicalPanel.module.css
@@ -19,6 +19,21 @@
   gap: 12px;
 }
 
+.headerMeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  text-transform: none;
+}
+
+.headerCaption {
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  opacity: 0.75;
+  text-transform: uppercase;
+}
+
 .timestamp {
   font-size: 10px;
   letter-spacing: 0.2px;

--- a/client/src/components/analyse-v2/TechnicalPanel.tsx
+++ b/client/src/components/analyse-v2/TechnicalPanel.tsx
@@ -22,7 +22,10 @@ export function TechnicalPanel({ symbol, tf, data }: TechnicalPanelProps) {
     <div className={styles.card} role="region" aria-label="Technical breakdown">
       <div className={styles.header}>
         <span>Technical Breakdown</span>
-        {lastRun && <span className={styles.timestamp}>Last analysed · {lastRun}</span>}
+        <span className={styles.headerMeta}>
+          <span className={styles.headerCaption}>Analysed @ {tf}</span>
+          {lastRun && <span className={styles.timestamp}>Last analysed · {lastRun}</span>}
+        </span>
       </div>
       <div className={styles.body}>
         <div className={styles.subtle}>

--- a/client/src/pages/AnalyseV2.module.css
+++ b/client/src/pages/AnalyseV2.module.css
@@ -54,37 +54,38 @@
   opacity: 0.85;
 }
 
+.panelHeaderMeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  text-transform: none;
+}
+
+.panelHeaderCredits {
+  font-size: 11px;
+  letter-spacing: 0.2px;
+  opacity: 0.75;
+  text-transform: none;
+}
+
+.panelHeaderCaption {
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.panelHeaderSub {
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  opacity: 0.6;
+  text-transform: none;
+}
+
 .panelBody {
   flex: 1;
   padding: 0;
-}
-
-.syncBanner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 6px 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border-bottom: 1px solid var(--card-border, #2a2a2a);
-  font-size: 11px;
-  letter-spacing: 0.2px;
-}
-
-.syncButton {
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  background: transparent;
-  color: #f1f1f1;
-  border-radius: 6px;
-  padding: 3px 8px;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.2px;
-  cursor: pointer;
-}
-
-.syncButton:hover {
-  background: rgba(255, 255, 255, 0.1);
 }
 
 .dense {

--- a/client/src/pages/AnalyseV2.tsx
+++ b/client/src/pages/AnalyseV2.tsx
@@ -1,34 +1,136 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import styles from "./AnalyseV2.module.css";
 import { TechnicalPanel } from "@/components/analyse-v2/TechnicalPanel";
 import { ChartPanel } from "@/components/analyse-v2/ChartPanel";
 import { AISummaryPanel } from "@/components/analyse-v2/AISummaryPanel";
 import LeftControlBox from "@/components/analyse-v2/LeftControlBox";
 import { useCredits } from "@/stores/creditStore";
-import { getCached, kAI, kTech } from "@/lib/cache";
-import type { AIPayload, TechPayload } from "@/lib/analyseClient";
+import { getCached, kAI, kTech, setCached } from "@/lib/cache";
+import { COST, spendGuard } from "@/lib/credits";
+import {
+  computeAI,
+  computeTechnicalAll,
+  type AIPayload,
+  type TechPayload,
+} from "@/lib/analyseClient";
+import { relativeTimeFrom } from "@/lib/time";
 
 type Timeframe = "15m" | "1h" | "4h" | "1d";
 
 export default function AnalyseV2() {
   const [symbol, setSymbol] = useState("INJUSDT");
-  const [tfDisplay, setTfDisplay] = useState<Timeframe>("1h");
   const [tfAnalysis, setTfAnalysis] = useState<Timeframe>("1h");
+  const [tfChart, setTfChart] = useState<Timeframe>("1h");
   const [techState, setTechState] = useState<TechPayload | null>(null);
   const [aiState, setAiState] = useState<AIPayload | null>(null);
+  const [loading, setLoading] = useState<"tech" | "ai" | null>(null);
 
-  const { credits } = useCredits();
+  const { credits, canSpend, spend, refund } = useCredits();
 
   useEffect(() => {
+    setTechState(null);
+    setAiState(null);
     const tech = getCached<TechPayload>(kTech(symbol, tfAnalysis));
     setTechState(tech ?? null);
     const ai = getCached<AIPayload>(kAI(symbol, tfAnalysis));
     setAiState(ai ?? null);
   }, [symbol, tfAnalysis]);
 
-  const handleSync = () => {
-    setTfAnalysis(tfDisplay);
+  const keyTech = useMemo(() => kTech(symbol, tfAnalysis), [symbol, tfAnalysis]);
+  const keyAI = useMemo(() => kAI(symbol, tfAnalysis), [symbol, tfAnalysis]);
+
+  const hasTechCache = Boolean(getCached<TechPayload>(keyTech));
+  const hasAiCache = Boolean(getCached<AIPayload>(keyAI));
+
+  const canAffordTech = canSpend(COST.TECH);
+  const canAffordAI = canSpend(COST.AI);
+
+  const handleRunTech = async () => {
+    if (loading) return;
+    const cached = getCached<TechPayload>(keyTech);
+    if (cached) {
+      setTechState(cached);
+      return;
+    }
+    if (!canSpend(COST.TECH)) return;
+    setLoading("tech");
+    try {
+      await spendGuard(
+        canSpend,
+        spend,
+        refund,
+        COST.TECH,
+        "tech",
+        async () => {
+          const tech = await computeTechnicalAll(symbol, tfAnalysis);
+          setCached(keyTech, tech);
+          setTechState(tech);
+          return tech;
+        },
+        { symbol, tf: tfAnalysis },
+      );
+    } finally {
+      setLoading(null);
+    }
   };
+
+  const handleRunAI = async () => {
+    if (loading) return;
+    const cachedAI = getCached<AIPayload>(keyAI);
+    if (cachedAI) {
+      setAiState(cachedAI);
+      const cachedTech = getCached<TechPayload>(keyTech);
+      if (cachedTech) {
+        setTechState(cachedTech);
+      }
+      return;
+    }
+    if (!canSpend(COST.AI)) return;
+    setLoading("ai");
+    try {
+      await spendGuard(
+        canSpend,
+        spend,
+        refund,
+        COST.AI,
+        "ai",
+        async () => {
+          const tech = await (async () => {
+            const cachedTech = getCached<TechPayload>(keyTech);
+            if (cachedTech) return cachedTech;
+            const computed = await computeTechnicalAll(symbol, tfAnalysis);
+            setCached(keyTech, computed);
+            return computed;
+          })();
+          setTechState(tech);
+          const ai = await computeAI(symbol, tfAnalysis, tech);
+          setCached(keyAI, ai);
+          setAiState(ai);
+          return ai;
+        },
+        { symbol, tf: tfAnalysis },
+      );
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  const techDisabled =
+    loading === "ai" || (!canAffordTech && !hasTechCache && !techState);
+  const aiDisabled =
+    loading === "tech" || (!canAffordAI && !hasAiCache && !aiState);
+
+  const techTooltip =
+    !canAffordTech && !hasTechCache && !techState
+      ? "Not enough credits. Buy more to continue."
+      : "Runs all indicators (RSI, MACD, ADX, EMAs, ATR, volume stats, SR proximity) for the selected timeframe. Uses 2 credits per timeframe. Cached ~10 min.";
+
+  const aiTooltip =
+    !canAffordAI && !hasAiCache && !aiState
+      ? "Not enough credits. Buy more to continue."
+      : "Computes technicals and generates an AI summary with entry/target/invalidation for the selected timeframe. Uses 5 credits per timeframe. Cached ~10 min.";
+
+  const aiLastRun = relativeTimeFrom(aiState?.generatedAt);
 
   return (
     <div className={styles.layout}>
@@ -40,22 +142,28 @@ export default function AnalyseV2() {
             onChangeSymbol={(next) => setSymbol(next)}
             onChangeTimeframe={(nextTf) => {
               setTfAnalysis(nextTf);
-              setTfDisplay(nextTf);
+              setTfChart(nextTf);
             }}
-            setTechState={setTechState}
-            setAIState={setAiState}
+            credits={credits}
+            loading={loading}
+            onRunTech={handleRunTech}
+            onRunAI={handleRunAI}
+            techDisabled={techDisabled}
+            aiDisabled={aiDisabled}
+            techTooltip={techTooltip}
+            aiTooltip={aiTooltip}
           />
           <TechnicalPanel symbol={symbol} tf={tfAnalysis} data={techState} />
         </div>
       </section>
 
       <section className={`${styles.panel} ${styles.panelChart}`}>
-        <div className={styles.panelHeader}>Chart</div>
+        <div className={styles.panelHeader}>Chart @ {tfChart}</div>
         <div className={styles.panelBody}>
           <ChartPanel
             symbol={symbol}
-            tf={tfDisplay}
-            onChangeDisplayTf={(next) => setTfDisplay(next)}
+            tf={tfChart}
+            onChangeChartTf={(next) => setTfChart(next)}
           />
         </div>
       </section>
@@ -63,18 +171,29 @@ export default function AnalyseV2() {
       <section className={`${styles.panel} ${styles.panelAI} ${styles.dense}`}>
         <div className={styles.panelHeader}>
           <span>AI Summary</span>
-          <span style={{ opacity: 0.7 }}>Credits: {credits}</span>
-        </div>
-        {tfDisplay !== tfAnalysis && (
-          <div className={styles.syncBanner}>
-            Chart: {tfDisplay} · Analysis: {tfAnalysis}
-            <button type="button" onClick={handleSync} className={styles.syncButton}>
-              Sync
-            </button>
+          <div className={styles.panelHeaderMeta}>
+            <span className={styles.panelHeaderCredits}>Credits: {credits}</span>
+            {aiState && (
+              <>
+                <span className={styles.panelHeaderCaption}>Analysed @ {tfAnalysis}</span>
+                {aiLastRun && (
+                  <span className={styles.panelHeaderSub}>Last analysed · {aiLastRun}</span>
+                )}
+              </>
+            )}
           </div>
-        )}
+        </div>
         <div className={styles.panelBody}>
-          <AISummaryPanel symbol={symbol} tf={tfAnalysis} data={aiState} />
+          <AISummaryPanel
+            symbol={symbol}
+            tf={tfAnalysis}
+            data={aiState}
+            hasTechnical={Boolean(techState)}
+            onRunAI={handleRunAI}
+            aiDisabled={aiDisabled}
+            aiTooltip={aiTooltip}
+            isLoading={loading === "ai"}
+          />
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- introduce distinct analysis and chart timeframe state on Analyse v2 and pass them to the relevant panels
- refresh technical and AI panels with analysed-time captions, last-run metadata, and the AI overlay CTA that reuses cached results when possible
- update the control box buttons with credit-aware tooltips, dual-action flow, and remove the legacy sync UI from the layout

## Testing
- npm run check *(fails: pre-existing TypeScript errors in ai-insights, home, and store modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e584034c44832392b19cb783459ac8