### PR TITLE
Scope credits by user and hydrate on auth

### DIFF
--- a/client/src/components/analyse-v2/LeftControlBox.tsx
+++ b/client/src/components/analyse-v2/LeftControlBox.tsx
@@ -8,6 +8,7 @@ type Props = {
   onChangeSymbol: (s: string) => void;
   onChangeTimeframe: (tf: Timeframe) => void;
   credits: number;
+  creditsReady: boolean;
   loading: "tech" | "ai" | null;
   onRunTech: () => void;
   onRunAI: () => void;
@@ -25,6 +26,7 @@ export default function LeftControlBox({
   onChangeSymbol,
   onChangeTimeframe,
   credits,
+  creditsReady,
   loading,
   onRunTech,
   onRunAI,
@@ -72,7 +74,9 @@ export default function LeftControlBox({
       </div>
 
       <div className={styles.creditsRow}>
-        <span className={styles.creditsChip}>Credits: {credits}</span>
+        <span className={styles.creditsChip}>
+          Credits: {creditsReady ? credits : "…"}
+        </span>
       </div>
 
       <div className={styles.actions}>

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,7 +1,8 @@
 import { useFirebaseAuth } from "./useFirebaseAuth";
 
 export function useAuth() {
-    const { user, loading, idToken, getIdToken, signInWithGoogle, signOut } = useFirebaseAuth();
+  const { user, loading, idToken, getIdToken, signInWithGoogle, signOut } =
+    useFirebaseAuth();
   return {
     user,
     idToken,
@@ -9,6 +10,7 @@ export function useAuth() {
     signInWithGoogle,
     signOut,
     isLoading: loading,
+    authReady: !loading,
     isAuthenticated: !!user,
   };
 }

--- a/client/src/stores/creditStore.ts
+++ b/client/src/stores/creditStore.ts
@@ -1,46 +1,130 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
 
-export type CreditStore = {
+export type CreditTxn = {
+  id: string;
+  at: number;
+  cost: number;
+  memo: string;
+  symbol?: string;
+  tf?: string;
+};
+
+type State = {
+  ready: boolean;
+  userId: string | null;
   credits: number;
-  canSpend: (amount: number) => boolean;
-  spend: (amount: number, memo: string, meta?: any) => boolean;
-  refund: (amount: number, memo: string, meta?: any) => void;
-  grant: (amount: number) => void;
+  txns: CreditTxn[];
+  init: (userId: string | null) => void;
+  canSpend: (n: number) => boolean;
+  spend: (n: number, memo: string, meta?: any) => boolean;
+  refund: (n: number, memo: string, meta?: any) => void;
+  grant: (n: number, memo?: string) => void;
 };
 
-const storage =
-  typeof window === "undefined"
-    ? undefined
-    : createJSONStorage(() => window.localStorage);
+const storageKey = (uid: string | null) =>
+  uid ? `credits:${uid}:v1` : `credits:anon:v1`;
 
-const persistOptions = {
-  name: "credits:v1",
-  partialize: (state: CreditStore) => ({ credits: state.credits }),
-  ...(storage ? { storage } : {}),
-};
+export const useCredits = create<State>((set, get) => ({
+  ready: false,
+  userId: null,
+  credits: 0,
+  txns: [],
+  init: (userId) => {
+    if (typeof window === "undefined") {
+      set({ userId, credits: 0, txns: [], ready: true });
+      return;
+    }
 
-export const useCredits = create<CreditStore>()(
-  persist(
-    (set, get) => ({
-      credits: 20,
-      canSpend: (amount: number) => get().credits >= amount,
-      spend: (amount: number, _memo: string, _meta?: any) => {
-        if (get().credits < amount) {
-          return false;
-        }
-        set((state) => ({ credits: state.credits - amount }));
-        return true;
-      },
-      refund: (amount: number, _memo: string, _meta?: any) => {
-        set((state) => ({ credits: state.credits + amount }));
-      },
-      grant: (amount: number) => {
-        set((state) => ({ credits: state.credits + amount }));
-      },
-    }),
-    persistOptions,
-  ),
-);
+    set({ ready: false });
+    const key = storageKey(userId);
+
+    const legacyKey = "credits:v1";
+    const legacyRaw = window.localStorage.getItem(legacyKey);
+    if (legacyRaw && !window.localStorage.getItem(key)) {
+      window.localStorage.setItem(key, legacyRaw);
+      window.localStorage.removeItem(legacyKey);
+    }
+
+    const raw = window.localStorage.getItem(key);
+    let credits = 20;
+    let txns: CreditTxn[] = [];
+
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as Partial<State> & {
+          txns?: CreditTxn[];
+        };
+        credits = typeof parsed.credits === "number" ? parsed.credits : 20;
+        txns = Array.isArray(parsed.txns) ? parsed.txns : [];
+      } catch {
+        credits = 20;
+        txns = [];
+      }
+    } else {
+      window.localStorage.setItem(key, JSON.stringify({ credits, txns }));
+    }
+
+    set({ userId, credits, txns, ready: true });
+  },
+  canSpend: (n) => get().credits >= n,
+  spend: (n, memo, meta) => {
+    if (get().credits < n) return false;
+    const txn: CreditTxn = {
+      id: crypto.randomUUID(),
+      at: Date.now(),
+      cost: -n,
+      memo,
+      ...(meta ?? {}),
+    };
+    const nextCredits = get().credits - n;
+    const nextTxns = [...get().txns, txn];
+    const key = storageKey(get().userId);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ credits: nextCredits, txns: nextTxns }),
+      );
+    }
+    set({ credits: nextCredits, txns: nextTxns });
+    return true;
+  },
+  refund: (n, memo, meta) => {
+    const txn: CreditTxn = {
+      id: crypto.randomUUID(),
+      at: Date.now(),
+      cost: n,
+      memo,
+      ...(meta ?? {}),
+    };
+    const nextCredits = get().credits + n;
+    const nextTxns = [...get().txns, txn];
+    const key = storageKey(get().userId);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ credits: nextCredits, txns: nextTxns }),
+      );
+    }
+    set({ credits: nextCredits, txns: nextTxns });
+  },
+  grant: (n, memo = "grant") => {
+    const txn: CreditTxn = {
+      id: crypto.randomUUID(),
+      at: Date.now(),
+      cost: n,
+      memo,
+    };
+    const nextCredits = get().credits + n;
+    const nextTxns = [...get().txns, txn];
+    const key = storageKey(get().userId);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({ credits: nextCredits, txns: nextTxns }),
+      );
+    }
+    set({ credits: nextCredits, txns: nextTxns });
+  },
+}));
 
 export const useCreditStore = useCredits;


### PR DESCRIPTION
## Summary
- replace the credits store with a user-scoped version that migrates legacy data, seeds first-time users with 20 credits, and records transactions per user
- hydrate the credits store when authentication becomes ready, showing a loading shell until credit data is available
- update Analyse V2 UI components to render loading placeholders instead of flashing zero credits and adjust tooltips accordingly

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files such as ai-insights.tsx, home.tsx, and inability to resolve zustand types)*

------
https://chatgpt.com/codex/tasks/task_e_68e5997aad7483238f307ec21563b376